### PR TITLE
Fix JSON file and non-main entry file edge cases

### DIFF
--- a/routes/home/index.js
+++ b/routes/home/index.js
@@ -84,7 +84,10 @@ export default () => {
       console.log(
         `Recursively fetching ${packageJSON.name}@${packageJSON.version}`
       );
-      recursiveDependencyFetch(packageJSON).then(setCache);
+      Promise.all([
+        recursiveDependencyFetch(packageJSON),
+        recursiveDependencyFetch(packageJSON, request.url),
+      ]).then(([a, b]) => setCache({ ...a, ...b }));
     }
   }, [packageJSON.name, packageJSON.version]);
 


### PR DESCRIPTION
I found two edge cases for recursiveDependencyFetch.

The first was that it did not handle the `.json` extension as it tried adding `.js` to the end of it. So I have added that check in now and seems to work. Visit `/?servor` for an example.

I also realised that if you enter a package through a route that is not the package `main` file. Then the recursiveDependencyFetch would start running at the main and you would get inaccurate file meta back (it wouldn't try walk the file you were in). Visit `/?preact@8.4.2/src/preact.js` for an example.

This PR fixes both those edge cases hopefully 🤞 