### PR TITLE
Support editor user-selection in Firefox

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ const Home = () => {
                   fontFamily: '"Inconsolata", monospace',
                 }}
                 padding=${42}
-                disabled
+                readOnly
               />
               <pre key="pre">${file.code.slice(100000)}</pre>
             </article>


### PR DESCRIPTION
Firefox disables user selection on `disabled` form elements. To enable user selection across browsers we should use the `readOnly` attribute on the editor instead.