### PR TITLE
Fix for nested template string issue > #66

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -1158,11 +1158,11 @@ Prism.languages.clike = {
   }),
   Prism.languages.insertBefore('javascript', 'string', {
     'template-string': {
-      pattern: /`(?:\\[\s\S]|\${[^}]+}|[^\\`])*`/,
+      pattern: /`(?:\\[\s\S]|\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})+}|[^\\`])*`/,
       greedy: !0,
       inside: {
         interpolation: {
-          pattern: /\${[^}]+}/,
+          pattern: /\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})+}/,
           inside: {
             'interpolation-punctuation': {
               pattern: /^\${|}$/,


### PR DESCRIPTION
Attempted fix for issue #66 shamelessly taken from a recent PR for Prism:

https://github.com/PrismJS/prism/pull/1845/files

Have not yet tested on enough packages to be completely confident, but it looks promising and seems to work as expected for `?svelte@3.3.0/internal.js`. 

Keeping "[DO NOT MERGE YET]" in title until I've checked several packages: don't want code reviewers to get the impression that I've tested this much yet.