### PR TITLE
Cypress CI integration.

### DIFF
--- a/.sail.yml
+++ b/.sail.yml
@@ -1,26 +1,25 @@
 tasks:
   install:
-    image: node:carbon
+    image: cypress/browsers
     command:
       - yarn
     args:
       - install
-  prettier:
-    image: node:carbon
-    command:
-      - yarn
-    args:
-      - prettier
-      - --check
   lint:
-    image: node:carbon
+    image: cypress/browsers
     command:
       - yarn
     args:
       - lint
+  cypress:
+    image: cypress/browsers
+    command: 
+      - yarn
+    args:
+      - test
 
 workflow:
   - install
   - sail:parallel:
       - lint
-      - prettier
+      - cypress

--- a/components/Aside.js
+++ b/components/Aside.js
@@ -14,7 +14,7 @@ const FileList = ({ title, files, packageName }) => html`
   <ul key=${files.join('-')}>
     ${files.map(
       x => html`
-        <li key=${x.url} data-test=${'Item'}>
+        <li key=${x.url} data-test='Item'>
           ${FileIcon}
           <a
             onClick=${e => {

--- a/components/Aside.js
+++ b/components/Aside.js
@@ -14,7 +14,7 @@ const FileList = ({ title, files, packageName }) => html`
   <ul key=${files.join('-')}>
     ${files.map(
       x => html`
-        <li key=${x.url} data-test=${title + 'Item'}>
+        <li key=${x.url} data-test=${'Item'}>
           ${FileIcon}
           <a
             onClick=${e => {

--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,1 @@
-{}
+{ "video": false }

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1,24 +1,25 @@
 describe('Runpkg', () => {
-  let url;
-  before(() => {
-    url =
-      Cypress.env('env') === 'local'
-        ? 'http://localhost:8080'
-        : 'https://runpkg.com';
+    let url;
+    before(() => {
+      url =
+        Cypress.env('env') === 'local'
+          ? 'http://localhost:8080'
+          : 'https://runpkg.com';
+    });
+    it('Visits the page', () => {
+      cy.visit(url + '/');
+      cy.get('[data-test=Overlay-Button]', { timeout: 10000 }).click();
+      cy.url().should('include', '/?lodash-es');
+      cy.get('[data-test=title]').contains('lodash-es');
+      cy.get('[data-test=Item]', { timeout: 10000 })
+        .first()
+        .click();
+      cy.url().should('include', 'add.js');
+    });
+    it('When specified version no of dependencies is correct', () => {
+      cy.visit(url + '/?react@16.8.6/index.js');
+      cy.get('[data-test=title]').should('contain', 'react');
+      cy.get('[data-test=Item]').should('have.length', 2);
+    });
   });
-  it('Visits the page', () => {
-    cy.visit(url + '/');
-    cy.get('[data-test=Overlay-Button]', { timeout: 10000 }).click();
-    cy.url().should('include', '/?lodash-es');
-    cy.get('[data-test=title]').contains('lodash-es');
-    cy.get('[data-test=DependenciesItem]', { timeout: 10000 })
-      .first()
-      .click();
-    cy.url().should('include', 'add.js');
-  });
-  it('When specified version no of dependencies is correct', () => {
-    cy.visit(url + '/?react@16.8.6/index.js');
-    cy.get('[data-test=title]').should('contain', 'react');
-    cy.get('[data-test=DependenciesItem]').should('have.length', 2);
-  });
-});
+  

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prettier": "prettier --config .prettierrc --write \"./**/*.{css,html,json,md,yml}\"",
     "lint": "eslint --config .eslintrc \"./**/*.js\"",
-    "test": "concurrently --kill-others \"node_modules/servor/servor.js --no-browser --no-reload\" \"wait-on http-get://localhost:8080 && npx cypress run --browser chrome --env env=local\" "
+    "test": "cypress install && concurrently --kill-others \"node_modules/servor/servor.js --no-browser --no-reload\" \"wait-on http-get://localhost:8080 && npx cypress run --browser chrome --env env=local\" --success first "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
So I had a brain-spark this morning and I'm kinda annoyed I didn't think of it before!

So with Cypress we were having issues with the electron-browser doing es6 module imports from unpkg.com but it worked with chrome browser.
Soooo as sail.ci works with docker, why not just pull in a docker image which has chrome + node installed 🤯.

So this branch does that and everything worksgit add .

Also fixes failing cypress tests.