### PR TITLE
Clickable imports

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -3,7 +3,7 @@ import { html } from 'https://unpkg.com/rplus-production@1.0.0';
 import Editor from './Editor.js';
 import FileIcon from './FileIcon.js';
 
-export default ({ file }) => html`
+export default ({ file, dependencyState }) => html`
   <article>
     <h1>
       ${FileIcon}
@@ -13,6 +13,8 @@ export default ({ file }) => html`
       )}
     </h1>
     <${Editor}
+      dependencyState=${dependencyState}
+      url=${file.url}
       key="editor"
       value=${file.code.slice(0, 100000)}
       style=${{

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -711,8 +711,7 @@ var styles = {
     WebkitTextFillColor: 'transparent',
   },
   highlight: {
-    position: 'relative',
-    pointerEvents: 'none',
+    position: 'relative'
   },
   editor: {
     margin: 0,

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -30,6 +30,7 @@ const handleCtrlUp = e => {
 const anchorAppender = deps => {
   const dependenciesArray = deps.map(x => [x[0], x[1]]);
   dependenciesArray.forEach(y => {
+    console.log(document);
     const imports = [...document.querySelectorAll('.token.string')].find(x =>
       x.innerText.includes(y[0])
     );
@@ -588,6 +589,8 @@ var Editor = (function(_React$Component) {
       key: 'componentDidMount',
       value: function componentDidMount() {
         this._recordCurrentState();
+        window.addEventListener('keydown', handleCtrlDown, true);
+        window.addEventListener('keyup', handleCtrlUp, true);
       },
     },
     {
@@ -603,6 +606,13 @@ var Editor = (function(_React$Component) {
               this.props.dependencyState[this.props.url].dependencies
             )
           : null;
+      },
+    },
+    {
+      key: 'componentWillUnmount',
+      value: function componentWillUnmount() {
+        window.removeEventListener('keydown', handleCtrlDown, true);
+        window.removeEventListener('keyup', handleCtrlUp, true);
       },
     },
     {
@@ -707,8 +717,6 @@ var Editor = (function(_React$Component) {
             _extends(
               {
                 onClick: handleEditorOnClick,
-                onKeyDown: handleCtrlDown,
-                onKeyUp: handleCtrlUp,
                 'aria-hidden': 'true',
                 style: _extends(
                   {},

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -18,7 +18,8 @@ const handleCtrlDown = e => {
 };
 
 const handleCtrlUp = e => {
-  if (e.key === 'meta' || e.key === 'ctrlKey') {
+  console.log(e);
+  if (e.key === 'Meta' || e.key === 'Control') {
     document
       .querySelectorAll('.imports')
       .forEach(x => x.classList.remove('ctrl'));

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -11,6 +11,20 @@ const handleEditorOnClick = e => {
   }
 };
 
+const handleCtrlDown = e => {
+  if (e.keyCode === 17 || e.keyCode === 91) {
+    document.querySelectorAll('.imports').forEach(x => x.classList.add('ctrl'));
+  }
+};
+
+const handleCtrlUp = e => {
+  if (e.keyCode === 17 || e.keyCode === 91) {
+    document
+      .querySelectorAll('.imports')
+      .forEach(x => x.classList.remove('ctrl'));
+  }
+};
+
 // this function maps over dependencies and appends
 // anchor tags to imports in the editor
 const anchorAppender = deps => {
@@ -141,7 +155,7 @@ var cssText =
   ' {\n    color: transparent !important;\n  }\n\n  .' +
   className +
   '::selection {\n    background-color: #accef7 !important;\n    color: transparent !important;\n  }\n}\n' +
-  '\na {text-decoration: none} .imports:hover {text-decoration: underline; \n text-decoration-color: white;}';
+  '\na {text-decoration: none} .imports:hover {text-decoration: underline; \n text-decoration-color: white;} .ctrl{text-decoration: underline; \n text-decoration-color: white;}';
 
 var Editor = (function(_React$Component) {
   _inherits(Editor, _React$Component);
@@ -693,6 +707,8 @@ var Editor = (function(_React$Component) {
             _extends(
               {
                 onClick: handleEditorOnClick,
+                onKeyDown: handleCtrlDown,
+                onKeyUp: handleCtrlUp,
                 'aria-hidden': 'true',
                 style: _extends(
                   {},

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -1,5 +1,37 @@
 import { react as React, html } from 'https://unpkg.com/rplus-production@1.0.0';
 
+import pushState from '../utils/pushState.js';
+
+// redirects req from unpkg -> runpkg
+const handleEditorOnClick = e => {
+  const href = e.nativeEvent.target.parentNode.href;
+  if (href) {
+    e.preventDefault();
+    pushState(href.replace('https://unpkg.com/', '?'));
+  }
+};
+
+// this function maps over dependencies and appends
+// anchor tags to imports in the editor
+const anchorAppender = deps => {
+  const dependenciesArray = deps.map(x => [x[0], x[1]]);
+  dependenciesArray.forEach(y => {
+    const imports = [...document.querySelectorAll('.token.string')].find(x =>
+      x.innerText.includes(y[0])
+    );
+    if (!imports) {
+      return;
+    }
+    const clonedImports = imports.cloneNode(true);
+    clonedImports.classList.add('imports');
+    const anchor = document.createElement('a');
+    anchor.href = y[1];
+    anchor.appendChild(clonedImports);
+    imports.replaceWith(anchor);
+  });
+  return;
+};
+
 /*eslint-disable */
 
 var _extends =
@@ -104,11 +136,12 @@ var className = 'npm__react-simple-code-editor__textarea';
 var cssText =
   /* CSS */ '\n/**\n * Reset the text fill color so that placeholder is visible\n */\n.' +
   className +
-  ":empty {\n  -webkit-text-fill-color: inherit !important;\n}\n\n/**\n * Hack to apply on some CSS on IE10 and IE11\n */\n@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {\n  /**\n    * IE doesn't support '-webkit-text-fill-color'\n    * So we use 'color: transparent' to make the text transparent on IE\n    * Unlike other browsers, it doesn't affect caret color in IE\n    */\n  ." +
+  ":empty {\n  -webkit-text-fill-color: inherit !important;\n}\n\n/**\n * Hack to apply on some CSS on IE10 and IE11\n */\n@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {\n  /**\n    * IE does n't support '-webkit-text-fill-color'\n    * So we use 'color: transparent' to make the text transparent on IE\n    * Unlike other browsers, it doesn't affect caret color in IE\n    */\n  ." +
   className +
   ' {\n    color: transparent !important;\n  }\n\n  .' +
   className +
-  '::selection {\n    background-color: #accef7 !important;\n    color: transparent !important;\n  }\n}\n';
+  '::selection {\n    background-color: #accef7 !important;\n    color: transparent !important;\n  }\n}\n' +
+  '\na {text-decoration: none} .imports:hover {text-decoration: underline; \n text-decoration-color: white;}';
 
 var Editor = (function(_React$Component) {
   _inherits(Editor, _React$Component);
@@ -544,6 +577,21 @@ var Editor = (function(_React$Component) {
       },
     },
     {
+      key: 'componentDidUpdate',
+      value: function componentDidUpdate() {
+        // narly check but it works
+        Object.entries(this.props.dependencyState).length !== 0 &&
+        this.props.dependencyState[this.props.url] &&
+        this.props.dependencyState[this.props.url].hasOwnProperty(
+          'dependencies'
+        )
+          ? anchorAppender(
+              this.props.dependencyState[this.props.url].dependencies
+            )
+          : null;
+      },
+    },
+    {
       key: 'render',
       value: function render() {
         var _this2 = this;
@@ -644,6 +692,7 @@ var Editor = (function(_React$Component) {
             'pre',
             _extends(
               {
+                onClick: handleEditorOnClick,
                 'aria-hidden': 'true',
                 style: _extends(
                   {},
@@ -711,7 +760,7 @@ var styles = {
     WebkitTextFillColor: 'transparent',
   },
   highlight: {
-    position: 'relative'
+    position: 'relative',
   },
   editor: {
     margin: 0,

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -12,13 +12,13 @@ const handleEditorOnClick = e => {
 };
 
 const handleCtrlDown = e => {
-  if (e.keyCode === 17 || e.keyCode === 91) {
+  if (e.metaKey || e.ctrlKey) {
     document.querySelectorAll('.imports').forEach(x => x.classList.add('ctrl'));
   }
 };
 
 const handleCtrlUp = e => {
-  if (e.keyCode === 17 || e.keyCode === 91) {
+  if (e.key === 'meta' || e.key === 'ctrlKey') {
     document
       .querySelectorAll('.imports')
       .forEach(x => x.classList.remove('ctrl'));

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -30,7 +30,6 @@ const handleCtrlUp = e => {
 const anchorAppender = deps => {
   const dependenciesArray = deps.map(x => [x[0], x[1]]);
   dependenciesArray.forEach(y => {
-    console.log(document);
     const imports = [...document.querySelectorAll('.token.string')].find(x =>
       x.innerText.includes(y[0])
     );

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1,25 +1,64 @@
 describe('Runpkg', () => {
-    let url;
-    before(() => {
-      url =
-        Cypress.env('env') === 'local'
-          ? 'http://localhost:8080'
-          : 'https://runpkg.com';
-    });
-    it('Visits the page', () => {
-      cy.visit(url + '/');
-      cy.get('[data-test=Overlay-Button]', { timeout: 10000 }).click();
-      cy.url().should('include', '/?lodash-es');
-      cy.get('[data-test=title]').contains('lodash-es');
-      cy.get('[data-test=Item]', { timeout: 10000 })
-        .first()
-        .click();
-      cy.url().should('include', 'add.js');
-    });
-    it('When specified version no of dependencies is correct', () => {
-      cy.visit(url + '/?react@16.8.6/index.js');
-      cy.get('[data-test=title]').should('contain', 'react');
-      cy.get('[data-test=Item]').should('have.length', 2);
-    });
+  let url;
+  before(() => {
+    url =
+      Cypress.env('env') === 'local'
+        ? 'http://localhost:8080'
+        : 'https://runpkg.com';
   });
-  
+  it('Visits the page', () => {
+    cy.visit(url + '/');
+    cy.get('[data-test=Overlay-Button]', { timeout: 10000 }).click();
+    cy.url().should('include', '/?lodash-es');
+    cy.get('[data-test=title]').contains('lodash-es');
+    cy.get('[data-test=Item]', { timeout: 10000 })
+      .first()
+      .click();
+    cy.url().should('include', 'add.js');
+  });
+  it('When specified version no of dependencies is correct', () => {
+    cy.visit(url + '/?react@16.8.6/index.js');
+    cy.get('[data-test=title]').should('contain', 'react');
+    cy.get('[data-test=Item]').should('have.length', 2);
+  });
+  it('When there are imports highlight functionality works', () => {
+    cy.visit(url + '/?lodash-es');
+    cy.get('.imports', { timeout: 100000 })
+      .first()
+      .should(el => {
+        expect(el).to.not.have.css('text-decoration', 'underline');
+      });
+    cy.get('.imports')
+      .first()
+      .trigger('keydown', { keyCode: 91 })
+      .should(el => {
+        expect(el).to.have.css(
+          'text-decoration',
+          'underline solid rgb(255, 255, 255)'
+        );
+      });
+    cy.get('.imports')
+      .first()
+      .trigger('keyup', { keyCode: 91 })
+      .should(el => {
+        expect(el).to.not.have.css(
+          'text-decoration',
+          'underline solid rgb(255, 255, 255)'
+        );
+      });
+    //     cy.get('.imports')
+    //     .first()
+    //
+    //     .should('have.css', 'text-decoration')
+    //     .and('match', 'underline');
+    //   cy.get('.imports')
+    //     .first()
+    //     .should('have.attribute', '.ctrl')
+    //     .should('have.css', 'text-decoration')
+    //     .and('match', 'underline');
+    //   cy.get('.imports')
+    //     .first()
+    //     .trigger('keyup', 91)
+    //     .should('not.have.css', 'text-decoration');
+  });
+});

--- a/index.js
+++ b/index.js
@@ -34,6 +34,14 @@ export const DependencyContext = react.createContext(null);
 
 const DependencyContextProvider = props => {
   const [dependencyState, setdependencyState] = react.useState({});
+
+  // This useEffect makes sure that our context updates with the file
+  // updates, otherwise this results in our editor trying to determine
+  // dependencies with an out of date file.url
+
+  react.useEffect(() => {
+    setdependencyState(state => ({ ...state }));
+  }, [props.file]);
   return html`
        <${DependencyContext.Provider} value=${[
     dependencyState,
@@ -134,7 +142,7 @@ const Home = () => {
         ? null
         : html`
               <${Nav} versions=${versions} file=${file} />    
-              <${DependencyContextProvider}>
+              <${DependencyContextProvider} file=${file}>
               <${DependencyContext.Consumer}>
                 ${([dependencyState]) =>
                   html`

--- a/index.js
+++ b/index.js
@@ -28,6 +28,22 @@ const parseUrl = (
     .join('/'),
 });
 
+// Initialise context for passing cache from Aside to Article
+
+export const DependencyContext = react.createContext(null);
+
+const DependencyContextProvider = props => {
+  const [dependencyState, setdependencyState] = react.useState({});
+  return html`
+       <${DependencyContext.Provider} value=${[
+    dependencyState,
+    setdependencyState,
+  ]}>
+${props.children}
+              </${DependencyContext.Provider}>
+        `;
+};
+
 const Home = () => {
   const [request, setRequest] = react.useState(parseUrl());
   const [file, setFile] = react.useState({});
@@ -117,11 +133,21 @@ const Home = () => {
         : isEmpty(file)
         ? null
         : html`
-            <${Nav} versions=${versions} file=${file} />
-            <${Article} file=${file} />
-            <${Aside} file=${file} />
-            <${Footer} />
-          `}
+              <${Nav} versions=${versions} file=${file} />    
+              <${DependencyContextProvider}>
+              <${DependencyContext.Consumer}>
+                ${([dependencyState]) =>
+                  html`
+                    <${Article}
+                      file=${file}
+                      dependencyState=${dependencyState}
+                    />
+                  `}
+              </${DependencyContext.Consumer}>
+              <${Aside} file=${file} />
+              </${DependencyContextProvider}>
+              <${Footer} />
+            `}
     </main>
   `;
 };

--- a/utils/makePath.js
+++ b/utils/makePath.js
@@ -1,0 +1,24 @@
+import fileNameRegEx from '../utils/fileNameRegEx.js';
+
+const UNPKG = 'https://unpkg.com/';
+
+// Handles paths like "../../some-file.js"
+const handleDoubleDot = (pathEnd, base) => {
+  const howFarBack = -1 * pathEnd.match(/\.\.\//g).length;
+  const strippedPathEnd = pathEnd.replace(/\.\./g, '').replace(/\/+/g, '/');
+  const strippedBase = base
+    .split('/')
+    .slice(0, howFarBack)
+    .join('/');
+  return strippedBase + strippedPathEnd;
+};
+
+const makePath = url => x => {
+  const base = url.replace(fileNameRegEx, '');
+  if (x.startsWith('./')) return base + x.replace('./', '/');
+  if (x.startsWith('../')) return handleDoubleDot(x, base);
+  if (x.startsWith('https://')) return x;
+  return UNPKG + x;
+};
+
+export default makePath;

--- a/utils/pushState.js
+++ b/utils/pushState.js
@@ -1,0 +1,1 @@
+export default url => history.pushState(null, null, url);

--- a/utils/recursiveDependencyFetch.js
+++ b/utils/recursiveDependencyFetch.js
@@ -28,10 +28,9 @@ const extractDependencies = (input, pkg) => {
 
   // Return array of unique dependencies appending js
   // extension to any relative imports that have no extension
-  const ggg = [...new Set([...imports, ...requires])].map(x =>
+  return [...new Set([...imports, ...requires])].map(x =>
     isExternalPath(x) || isLocalFile(x) ? x : `${x}.js`
   );
-  return ggg;
 };
 
 const packageJsonUrl = path => {

--- a/utils/recursiveDependencyFetch.js
+++ b/utils/recursiveDependencyFetch.js
@@ -94,8 +94,8 @@ const recursiveDependantsFetch = async (path, parent, fileCache, pkgCache) => {
   // If we asked for a file but got redirected by unpkg
   // then update the url in the parents dependencies
   if (cache[parent] && path !== url) {
-    const position = cache[parent].dependencies.indexOf(path);
-    cache[parent].dependencies[position] = url;
+    const position = cache[parent].dependencies.map(x => x[1]).indexOf(path);
+    cache[parent].dependencies[position][1] = url;
   }
 
   // Checks if we've already fetched the file and dependencies

--- a/utils/recursiveDependencyFetch.js
+++ b/utils/recursiveDependencyFetch.js
@@ -35,7 +35,6 @@ const extractDependencies = (input, pkg) => {
 };
 
 const packageJsonUrl = path => {
-  console.log(path);
   const [_full, name, version] = path.match(
     /https:\/\/unpkg.com\/(@?[^@\n]*)@?(\d+\.\d+\.\d+)?/
   );


### PR DESCRIPTION
So this is a big change to the editor component to do #43.

Essentially if you click on any import inline it will take you to that file. 

My initial approach was to bake this into the parser which was fun. But @VirtualDOMinic pointed out that this wasn't really the 'react' way and meant we had potentially two sources of truth for our dependencies. 

So we added a context `DependencyContext` to provide a source of truth for our dependencies in Editor.js. 
Our recursive dependency fetch would push its cache to `DependencyContext` when finished then our Editor.js consumes the data in its own `anchorAppender` function.
`anchorAppender` maps through dependencies and adds anchor tags to elements with imports/requires/exports that matched the dependencies.
This only runs when the Editor.js component updates (with path change) so whilst not using the vdom, this is at least using lifecycle methods meaning we don't have any gnarly functions to check for path change.

We also have redirects of unpkg urls on the appended anchor tags to runpkg urls, thanks to @VirtualDOMinic! 

There is also styling when hovering import links, or when pressing ctrl/cmd it will highlight all.

There are probably ways to make this more efficient, @lukejacksonn feel free to pipe in! 

Also there are cypress tests for this new functionality.