### PR TITLE
FixForScriptTag

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       href="https://fonts.googleapis.com/css?family=Bai+Jamjuree"
       rel="stylesheet"
     />
-    <script defer src="/index.js" type="module"></script>
+    <script src="/index.js" type="module"></script>
     <meta property="og:site_name" content="runpkg" />
     <meta property="og:title" content="runpkg | the package explorer" />
     <meta name="twitter:title" content="runpkg | the package explorer" />


### PR DESCRIPTION
Quick fix: 

[Article on defer with es6 modules](https://developers.google.com/web/fundamentals/primers/modules#defer)

1. Removed defer as redundant (ran through w3c validator trying to fix edge)