### PR TITLE
Dedupe dependency fetching in recursiveDependencyFetch.

### DIFF
--- a/utils/recursiveDependencyFetch.js
+++ b/utils/recursiveDependencyFetch.js
@@ -71,9 +71,9 @@ class PkgCache {
     if (this.cache.has(key)) {
       return await this.cache.get(key);
     }
-    const resultPromise = fetch(key).then(
-      fetch(key).then(async res => await res.json())
-    );
+    const resultPromise = fetch(key)
+      .then(fetch(key))
+      .then(res => res.json());
     this.cache.set(key, resultPromise);
     return await resultPromise;
   }


### PR DESCRIPTION
This fixes #60 

1. Changed fetching of files + package.jsons to use a class which maintains its own map of what it has fetched. Resulting in IMO more comprehendible code and it fixes duplications of the same dependency being fetched. 

1. Wrote some additional documentation where I can.

I'm not big on using classes at the best of times but the classes created are within the recursivedependencyfetch function scope and feel nicer to read than the previous currying + self-invocation. 

Happy to hear thoughts. 