### PR TITLE
Fix Svelte file resolution by assuming current path is a file, not a dir #64

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -18,7 +18,6 @@ const handleCtrlDown = e => {
 };
 
 const handleCtrlUp = e => {
-  console.log(e);
   if (e.key === 'Meta' || e.key === 'Control') {
     document
       .querySelectorAll('.imports')
@@ -29,8 +28,7 @@ const handleCtrlUp = e => {
 // this function maps over dependencies and appends
 // anchor tags to imports in the editor
 const anchorAppender = deps => {
-  const dependenciesArray = deps.map(x => [x[0], x[1]]);
-  dependenciesArray.forEach(y => {
+  deps.forEach(y => {
     const imports = [...document.querySelectorAll('.token.string')].find(x =>
       x.innerText.includes(y[0])
     );

--- a/index.js
+++ b/index.js
@@ -76,7 +76,6 @@ const Home = () => {
 
   // Runs once and subscribes to url changes
   react.useEffect(() => {
-    console.log('Setting up URL listener');
     // Rerender the app when pushState is called
     ['pushState'].map(event => {
       const original = window.history[event];

--- a/index.js
+++ b/index.js
@@ -28,6 +28,22 @@ const parseUrl = (
     .join('/'),
 });
 
+// For now, add warning in console if popular bundler detected
+const warnAboutBundler = pkgJSON => {
+  if (
+    Object.values(pkgJSON.scripts).some(
+      x =>
+        x.startsWith('rollup') ||
+        x.startsWith('webpack') ||
+        x.startsWith('parcel')
+    )
+  ) {
+    console.warn(
+      'Bundler (rollup, webpack or parcel) detected in package.json. File path resoltion may not work as expected on runpkg.'
+    );
+  }
+};
+
 // Initialise context for passing cache from Aside to Article
 
 export const DependencyContext = react.createContext(null);
@@ -102,6 +118,9 @@ const Home = () => {
         )
           .then(res => res.json())
           .catch(() => setFetchError(true));
+
+        if (pkg) warnAboutBundler(pkg);
+
         // Set the new state
         setFile({ url, meta, pkg, code });
         replaceState(`?${url.replace('https://unpkg.com/', '')}`);

--- a/utils/recursiveDependencyFetch.js
+++ b/utils/recursiveDependencyFetch.js
@@ -13,8 +13,14 @@ const handleDoubleDot = (pathEnd, base) => {
   return strippedBase + strippedPathEnd;
 };
 
+// Handles cases like Svelte, where - on runpkg - the index url doesn't have a file ext
+const getCurrentdir = currentPath =>
+  currentPath.match(fileNameRegEx)
+    ? currentPath.replace(fileNameRegEx, '')
+    : currentPath.replace(/\/[^\/]+$/, '');
+
 const makePath = url => x => {
-  const base = url.replace(fileNameRegEx, '');
+  const base = getCurrentdir(url);
   if (x.startsWith('./')) return base + x.replace('./', '/');
   if (x.startsWith('../')) return handleDoubleDot(x, base);
   if (x.startsWith('https://')) return x;


### PR DESCRIPTION
Contributes to (but does not fully close/fix) #64 

Compare sidebar for Svelte on this branch vs master to see effect of this

Seems to work fine!

Doesn't fix the clickable imports issue on Svelte, but I have come to the conclusion that it's out of scope. Think it'll over-complicate our app and a few things I tried seem pretty shaky... Will add to the discussion on #64 to explain more 