### PR TITLE
Refactor state to use useReducer.

### DIFF
--- a/components/Aside.js
+++ b/components/Aside.js
@@ -4,7 +4,6 @@ import Link from './Link.js';
 import formatBytes from '../utils/formatBytes.js';
 import Spinner from './Spinner.js';
 import FileIcon from './FileIcon.js';
-import { DependencyContext } from '../index.js';
 
 const FileList = ({ title, files, packageName }) => html`
   <div key=${title}>
@@ -36,13 +35,8 @@ const FileList = ({ title, files, packageName }) => html`
 //     {}
 //   );
 
-export default ({ file }) => {
+export default ({ file, dispatch }) => {
   const [cache, setCache] = react.useState({});
-
-  //eslint-disable-next-line no-unused-vars
-  const [dependencyState, setDependencyState] = react.useContext(
-    DependencyContext
-  );
 
   react.useEffect(() => {
     setCache({});
@@ -54,7 +48,7 @@ export default ({ file }) => {
         // Side effects for setting various caches
         //eslint-disable-next-line no-unused-expressions
         setCache(x);
-        setDependencyState(x);
+        dispatch({ type: 'setDependencies', payload: x });
       });
     }
   }, [file.url]);

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -27,12 +27,18 @@ export default ({ file, versions, dispatch }) => {
 
   const [selectedVersion, changeVersion] = react.useState(version);
 
+  // On package change
   react.useEffect(() => {
+    changeVersion(version);
+  }, [name]);
+
+  const handleVersionChange = v => {
+    changeVersion(v);
     const [, path] = file.url.match(
       /https:\/\/unpkg.com\/(?:@?[^@\n]*)@?(?:\d+\.\d+\.\d+)(.*)$/
     );
-    pushState(`?${name}@${selectedVersion}${path}`);
-  }, [selectedVersion]);
+    pushState(`?${name}@${v}${path}`);
+  };
 
   const Directory = ({ rootMeta }) => html`
     <ul>
@@ -84,7 +90,7 @@ export default ({ file, versions, dispatch }) => {
       <select
         id="version"
         value=${selectedVersion}
-        onChange=${e => changeVersion(e.target.value)}
+        onChange=${e => handleVersionChange(e.target.value)}
       >
         ${versions.length !== 0
           ? versions.map(

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -68,7 +68,7 @@ export default ({ file, versions, dispatch }) => {
       </h1>
       <button
         className="searchButton"
-        onClick=${() => dispatch({ type: 'open' })}
+        onClick=${() => dispatch({ type: 'setIsSearching', payload: true })}
       >
         ${SearchIcon}
       </button>

--- a/components/Search.js
+++ b/components/Search.js
@@ -92,7 +92,10 @@ export default ({ isSearching, dispatch }) => {
           open
         >
           <div>
-            <button onClick=${() => dispatch({ type: 'close' })}>
+            <button
+              onClick=${() =>
+                dispatch({ type: 'setIsSearching', payload: false })}
+            >
               ${CloseIcon}
             </button>
             <input

--- a/index.js
+++ b/index.js
@@ -54,7 +54,11 @@ const Home = () => {
       case 'setIsSearching':
         return { ...state, isSearching: action.payload };
       case 'setRequest':
-        return { ...state, request: action.payload, isSearching: false };
+        return {
+          ...state,
+          request: action.payload,
+          isSearching: false,
+        };
       case 'setFile':
         return { ...state, file: action.payload };
       case 'setFetchError':
@@ -113,7 +117,7 @@ const Home = () => {
     // Reset any previous state
     if (!state.request.package) {
       dispatch({ type: 'setFile', payload: {} });
-      dispatch({ type: 'setFetchError', payload: true });
+      dispatch({ type: 'setFetchError', payload: false });
     }
     if (state.request.package) {
       const { request } = state;


### PR DESCRIPTION
This PR cleans up a bunch of our state continuing from #91.

It puts all our useStates in the index.js into a useReducer state object. 
We can also remove the dependency context. 

This for me feels much easier to comprehend and maintain. 

Interested in opinions, especially whether we're okay with Search and others having their own localised state (IMO it's fine).