### PR TITLE
Update social share cards, add link back

### DIFF
--- a/components/Overlay.js
+++ b/components/Overlay.js
@@ -6,7 +6,9 @@ const pushState = url => history.pushState(null, null, url);
 
 export default html`
   <dialog open>
-    ${FormidableLogo}
+    <a href="https://formidable.com">
+      ${FormidableLogo}
+    </a>
     <div className="overlay">
       <${ProjectBadge}
         color="#80EAC7"

--- a/index.css
+++ b/index.css
@@ -367,12 +367,14 @@
   height: 100vh;
   width: 100%;
 
-  > svg {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-    width: 10vw;
-    fill: rgba(255, 255, 255, 0.1);
+  > a {
+    svg {
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+      width: 10vw;
+      fill: rgba(255, 255, 255, 0.1);
+    }
   }
 
   > div > * + * {

--- a/index.html
+++ b/index.html
@@ -34,11 +34,11 @@
     />
     <meta
       property="og:image"
-      content="https://www.formidable.com/static/no-img.1616989a.jpg"
+      content="https://formidable.com/static/social-preview.0eb61d35.png"
     />
     <meta
       property="twitter:image"
-      content="https://www.formidable.com/static/no-img.1616989a.jpg"
+      content="https://formidable.com/static/social-preview.0eb61d35.png"
     />
     <meta property="og:url" content="https://runpkg.com" />
     <meta property="twitter:domain" content="https://runpkg.com" />


### PR DESCRIPTION
@kiraarghy @VirtualDOMinic 

I noticed that `runpkg` was using an older version of our social share cards. 

This PR
- updates the social image to: https://formidable.com/static/social-preview.0eb61d35.png
- makes the formidable logo on the main page link back to formidable.com