### PR TITLE
add ethical-metrics v0.1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,16 @@
       rel="stylesheet"
     />
     <script src="/index.js" type="module"></script>
+    <script>
+      window.ETHICAL_METRICS_CONFIG = {
+        url:
+          'https://471y17zblc.execute-api.us-west-2.amazonaws.com/metrics/metrics-visit/',
+      };
+    </script>
+    <script
+      async
+      src="https://rawcdn.githack.com/chrisbolin/ethical-metrics/v0.1.0/packages/metrics-client/dist/index.js"
+    ></script>
     <meta property="og:site_name" content="runpkg" />
     <meta property="og:title" content="runpkg | the package explorer" />
     <meta name="twitter:title" content="runpkg | the package explorer" />


### PR DESCRIPTION
Adds the alpha 0.1.0 version of [ethical-metrics](https://github.com/chrisbolin/ethical-metrics).

I've talked with @jevakallio about this pretty extensively. ethical-metrics does a few things for us...
- tracks unique users and return visitors 
- does not use _any_ form of client storage: cookies, local storage, etc
- no inter-site tracking (re-targeting)
- data is not shared with 3rd parties, and would be worthless to them if it was leaked