### PR TITLE
Fix changing from a suffixed version

### DIFF
--- a/components/Nav.js
+++ b/components/Nav.js
@@ -34,9 +34,7 @@ export default ({ file, versions, dispatch }) => {
 
   const handleVersionChange = v => {
     changeVersion(v);
-    const [, path] = file.url.match(
-      /https:\/\/unpkg.com\/(?:@?[^@\n]*)@?(?:\d+\.\d+\.\d+)(.*)$/
-    );
+    const [, path] = file.url.match(/https:\/\/unpkg.com\/[^\/]*(\/?.*)$/);
     pushState(`?${name}@${v}${path}`);
   };
 
@@ -92,6 +90,7 @@ export default ({ file, versions, dispatch }) => {
         id="version"
         value=${selectedVersion}
         onChange=${e => handleVersionChange(e.target.value)}
+        data-test="version-selector"
       >
         ${versions.length !== 0
           ? versions.map(

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -34,7 +34,7 @@ export default ({ file, versions, dispatch }) => {
 
   const handleVersionChange = v => {
     changeVersion(v);
-    const [, path] = file.url.match(/https:\/\/unpkg.com\/[^\/]*(\/?.*)$/);
+    const [, path] = file.url.match(/https:\/\/unpkg\.com\/[^\/]*(\/?.*)$/);
     pushState(`?${name}@${v}${path}`);
   };
 

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -61,4 +61,9 @@ describe('Runpkg', () => {
     //     .trigger('keyup', 91)
     //     .should('not.have.css', 'text-decoration');
   });
+  it('Changes versions from version with suffix', () => {
+    cy.visit(url + '/?lodash@1.0.0-rc.1');
+    cy.get('[data-test=version-selector]', { timeout: 10000 }).select('4.11.2');
+    cy.url().should('include', '/?lodash@4.11.2/');
+  });
 });


### PR DESCRIPTION
- Modified the `changeVersion` regex to grab everything after the first path segment (package and version)
- Added test

Fixes #107 