### PR TITLE
[WIP] Refactor app state & URL handling

### DIFF
--- a/Home.js
+++ b/Home.js
@@ -1,0 +1,102 @@
+import { react, html, css } from 'https://unpkg.com/rplus-production@1.0.0';
+
+import Dialog from './components/Overlay.js';
+import Nav from './components/Nav.js';
+import Article from './components/Article.js';
+import Aside from './components/Aside.js';
+import Footer from './components/Footer.js';
+import NotFound from './components/NotFound.js';
+import Search from './components/Search.js';
+
+import RequestContext from './context/RequestContext.js';
+import FileContext from './context/FileContext.js';
+
+import fileNameRegEx from './utils/fileNameRegEx.js';
+
+const isEmpty = obj => Object.keys(obj).length === 0;
+
+function Home() {
+  const [isSearching, setIsSearching] = react.useState(false);
+
+  const { request } = react.useContext(RequestContext);
+  const { file, fetchError } = react.useContext(FileContext);
+
+  // function reducer(state, action) {
+  //   switch (action.type) {
+  //     case 'toggleIsSearching':
+  //       return { ...state, isSearching: !state.isSearching };
+  //     case 'setIsSearching':
+  //       return { ...state, isSearching: action.payload };
+  //     case 'setRequest':
+  //       return {
+  //         ...state,
+  //         request: action.payload,
+  //         isSearching: false,
+  //       };
+  //     case 'setFile':
+  //       return { ...state, file: action.payload };
+  //     case 'setFetchError':
+  //       return { ...state, fetchError: action.payload };
+  //     case 'setVersions':
+  //       return { ...state, versions: action.payload };
+  //     case 'setDependencies':
+  //       return { ...state, dependencyState: action.payload };
+  //     default:
+  //       return { ...state };
+  //   }
+  // }
+
+  // const [state, dispatch] = react.useReducer(reducer, {
+  //   isSearching: false,
+  //   request: parseUrl(),
+  //   file: {},
+  //   fetchError: false,
+  //   versions: [],
+  //   dependencyState: {},
+  // });
+
+  react.useEffect(() => {
+    const check = e => {
+      if (e.key === 'p' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setIsSearching(true);
+      }
+      if (e.key === 'Escape') setIsSearching(false);
+    };
+    window.addEventListener('keydown', check);
+  }, []);
+
+  react.useEffect(() => {
+    if (fetchError) {
+      document.title = '404 | runpkg';
+    } else if (request && request.package) {
+      document.title = request.package + ' | runpkg';
+    } else {
+      document.title = 'runpkg | the package explorer';
+    }
+  }, [request.url, fetchError]);
+
+  console.log(request);
+  return html`
+    <main className=${css`/index.css`}>
+      ${fetchError
+        ? NotFound
+        : isSearching
+        ? html`
+            <${Search} isSearching=${isSearching} />
+          `
+        : !request.url
+        ? Dialog
+        : isEmpty(file)
+        ? null
+        : html`
+            <${Nav} />
+            <${Article} />
+            <${Aside} />
+            <${Footer} />
+          `}
+    </main>
+  `;
+}
+
+export default Home;

--- a/components/Article.js
+++ b/components/Article.js
@@ -1,29 +1,35 @@
-import { html } from 'https://unpkg.com/rplus-production@1.0.0';
+import { react, html } from 'https://unpkg.com/rplus-production@1.0.0';
+
+import FileContext from '../context/FileContext.js';
 
 import Editor from './Editor.js';
 import FileIcon from './FileIcon.js';
 
-export default ({ file, dependencyState }) => html`
-  <article>
-    <h1>
-      ${FileIcon}
-      ${file.url.replace(
-        `https://unpkg.com/${file.pkg.name}@${file.pkg.version}`,
-        ''
-      )}
-    </h1>
-    <${Editor}
-      dependencyState=${dependencyState}
-      url=${file.url}
-      key="editor"
-      value=${file.code.slice(0, 100000)}
-      style=${{
-        lineHeight: '138%',
-        fontFamily: '"Inconsolata", monospace',
-      }}
-      padding=${42}
-      readOnly
-    />
-    <pre key="pre">${file.code.slice(100000)}</pre>
-  </article>
-`;
+export default ({ dependencyState }) => {
+  const { file } = react.useContext(FileContext);
+
+  return html`
+    <article>
+      <h1>
+        ${FileIcon}
+        ${file.url.replace(
+          `https://unpkg.com/${file.pkg.name}@${file.pkg.version}`,
+          ''
+        )}
+      </h1>
+      <${Editor}
+        dependencyState=${dependencyState}
+        url=${file.url}
+        key="editor"
+        value=${file.code.slice(0, 100000)}
+        style=${{
+          lineHeight: '138%',
+          fontFamily: '"Inconsolata", monospace',
+        }}
+        padding=${42}
+        readOnly
+      />
+      <pre key="pre">${file.code.slice(100000)}</pre>
+    </article>
+  `;
+};

--- a/components/Aside.js
+++ b/components/Aside.js
@@ -1,7 +1,11 @@
 import { react, html } from 'https://unpkg.com/rplus-production@1.0.0';
+
 import recursiveDependencyFetch from '../utils/recursiveDependencyFetch.js';
-import Link from './Link.js';
 import formatBytes from '../utils/formatBytes.js';
+
+import FileContext from '../context/FileContext.js';
+
+import Link from './Link.js';
 import Spinner from './Spinner.js';
 import FileIcon from './FileIcon.js';
 
@@ -39,7 +43,9 @@ const FileList = ({ title, files, packageName }) => html`
 //     {}
 //   );
 
-export default ({ file, dispatch }) => {
+export default ({ dispatch }) => {
+  const { file } = react.useContext(FileContext);
+
   const [cache, setCache] = react.useState({});
 
   react.useEffect(() => {

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -7,9 +7,16 @@ import CloseIcon from './CloseIcon.js';
 import SearchIcon from './SearchIcon.js';
 import Link from './Link.js';
 
+import FileContext from '../context/FileContext.js';
+
 const pushState = url => history.pushState(null, null, url);
 
-export default ({ file, versions, dispatch }) => {
+export default ({ dispatch }) => {
+  const { file } = react.useContext(FileContext);
+  const versions = [];
+
+  console.log(file);
+
   const [isNavShowing, showNav] = react.useState(false);
   const { name, version, main, license, description } = file.pkg;
 
@@ -102,7 +109,10 @@ export default ({ file, versions, dispatch }) => {
           : null}</select
       >
       <h2>Package Contents</h2>
-      <${Directory} rootMeta=${file.meta} />
+      ${file.meta &&
+        html`
+          <${Directory} rootMeta=${file.meta} />
+        `}
     </nav>
   `;
 };

--- a/context/FileContext.js
+++ b/context/FileContext.js
@@ -1,0 +1,117 @@
+import { react, html, css } from 'https://unpkg.com/rplus-production@1.0.0';
+
+import RequestContext from './RequestContext.js';
+
+const FileContext = react.createContext({
+  file: {
+    url: '',
+    meta: '',
+    pkg: '',
+    code: '',
+  },
+  fetchError: null,
+  setFile: () => {},
+});
+
+export function Provider({ children }) {
+  const request = {};
+  const [file, setFile] = react.useState({
+    url: '',
+    meta: null,
+    pkg: '',
+    code: '',
+  });
+  const [fetchError, setFetchError] = react.useState(false);
+
+  // Whenever the URL changes then:
+  // 1. Resolve the unpkg url and file contents for the request url
+  // 2. Fetch the package.json for the requested package
+  // 3. Fetch the /?meta for the requested package
+  react.useEffect(() => {
+    // Reset any previous state
+    if (!request.package) {
+      setFile({});
+    }
+    if (request.package) {
+      const { request } = state;
+      (async () => {
+        // Fetch the file contents and check for redirect
+        const { url, code } = await fetch(
+          `https://unpkg.com/${request.url}`
+        ).then(async res => ({
+          code: (await res.text()).replace(/\t/g, '  '),
+          url: res.url,
+        }));
+        // Fetch the meta data
+        const meta = await fetch(`https://unpkg.com/${request.package}/?meta`)
+          .then(res => res.json())
+          .catch(() => setFetchError(true));
+        // Fetch the package json
+        const pkg = await fetch(
+          `https://unpkg.com/${request.package}/package.json`
+        )
+          .then(res => res.json())
+          .catch(() => setFetchError(true));
+
+        if (pkg) warnAboutBundler(pkg);
+
+        // Set the new state
+        setFile({
+          url,
+          meta,
+          pkg,
+          code,
+        });
+        history.replaceState(
+          null,
+          null,
+          `?${url.replace('https://unpkg.com/', '')}`
+        );
+        // TODO: move to versions component
+        // try {
+        //   var parser = new DOMParser();
+        //   const unpkgPage = await fetch(
+        //     `https://unpkg.com/${request.package}/`
+        //   ).then(async res =>
+        //     parser.parseFromString(await res.text(), 'text/html')
+        //   );
+
+        //   const scriptElements = unpkgPage.getElementsByTagName('script');
+
+        //   dispatch({
+        //     type: 'setVersions',
+        //     payload: JSON.parse(
+        //       `${
+        //         Object.values(scriptElements)
+        //           .filter(x => x.innerHTML.includes('window.__DATA__'))[0]
+        //           .innerHTML.split('window.__DATA__ = ')[1]
+        //       }`
+        //     ).availableVersions,
+        //   });
+        // } catch (err) {
+        //   console.log('error in version parser');
+        //   console.log(err);
+        // }
+      })();
+    }
+  }, [request.url]);
+
+  return html`
+    <${FileContext.Provider}
+      value=${{
+        file,
+        setFile,
+        fetchError,
+      }}
+    >
+      ${children}
+    </${FileContext.Provider}>
+  `;
+}
+
+export const Consumer = FileContext.Consumer;
+export default FileContext;
+// {
+//   Provider: FileContextProvider,
+//   Consumer: FileContext.Consumer
+// }

--- a/context/RequestContext.js
+++ b/context/RequestContext.js
@@ -1,0 +1,66 @@
+import { react, html, css } from 'https://unpkg.com/rplus-production@1.0.0';
+
+import fileNameRegEx from '../utils/fileNameRegEx.js';
+
+const parseUrl = (
+  search = window.location.search.slice(1).replace(/\/$/, '')
+) => ({
+  url: search,
+  package: search.startsWith('@')
+    ? search
+        .split('/')
+        .slice(0, 2)
+        .join('/')
+    : search.split('/')[0],
+  folder: search.replace(fileNameRegEx, ''),
+  file: search
+    .split('/')
+    .slice(1)
+    .join('/'),
+});
+
+const RequestContext = react.createContext({
+  request: {
+    url: '',
+    package: '',
+    folder: '',
+    file: '',
+  },
+  setRequest: () => {},
+});
+
+export function Provider({ children }) {
+  const [request, setRequest] = react.useState(parseUrl());
+
+  react.useEffect(() => {
+    // monkey patch history.pushState to also parse the new
+    // url when called
+    const original = window.history.pushState;
+    window.history.pushState = function() {
+      console.log('pushstate');
+      original.apply(history, arguments);
+      setRequest(parseUrl());
+    };
+
+    // Rerender when the back and forward buttons are pressed
+    addEventListener('popstate', () => {
+      const parsedUrl = parseUrl();
+      console.log(parsedUrl);
+      setRequest(parsedUrl);
+    });
+  }, []);
+
+  return html`
+    <${RequestContext.Provider} value=${{
+    request,
+    setRequest,
+  }}>
+      ${children}
+    </${RequestContext.Provider}>
+  `;
+}
+
+export const Consumer = RequestContext.Consumer;
+export default RequestContext;
+
+// export const RequestContextConsumer = RequestContext.Consumer;

--- a/context/index.js
+++ b/context/index.js
@@ -1,0 +1,13 @@
+import { react, html, css } from 'https://unpkg.com/rplus-production@1.0.0';
+
+import { Provider as FileContextProvider } from './FileContext.js';
+import { Provider as RequestContextProvider } from './RequestContext.js';
+
+const ContextProviders = ({ children }) => html`
+  <${RequestContextProvider}>
+    <${FileContextProvider}>
+      ${children}
+    </${FileContextProvider}>
+  </${RequestContextProvider}>
+`;
+export default ContextProviders;

--- a/index.js
+++ b/index.js
@@ -1,220 +1,117 @@
 import { react, html, css } from 'https://unpkg.com/rplus-production@1.0.0';
 
-import Dialog from './components/Overlay.js';
-import Nav from './components/Nav.js';
-import Article from './components/Article.js';
-import Aside from './components/Aside.js';
-import Footer from './components/Footer.js';
-import NotFound from './components/NotFound.js';
-import Search from './components/Search.js';
+import Providers from './context/index.js';
 
-import fileNameRegEx from './utils/fileNameRegEx.js';
+import Home from './Home.js';
 
-const isEmpty = obj => Object.keys(obj).length === 0;
-const replaceState = url => history.replaceState(null, null, url);
-const parseUrl = (
-  search = window.location.search.slice(1).replace(/\/$/, '')
-) => ({
-  url: search,
-  package: search.startsWith('@')
-    ? search
-        .split('/')
-        .slice(0, 2)
-        .join('/')
-    : search.split('/')[0],
-  folder: search.replace(fileNameRegEx, ''),
-  file: search
-    .split('/')
-    .slice(1)
-    .join('/'),
-});
+// const isEmpty = obj => Object.keys(obj).length === 0;
 
-// For now, add warning in console if popular bundler detected
-const warnAboutBundler = pkgJSON => {
-  if (
-    pkgJSON.scripts instanceof Object &&
-    Object.values(pkgJSON.scripts).some(
-      x =>
-        x.startsWith('rollup') ||
-        x.startsWith('webpack') ||
-        x.startsWith('parcel')
-    )
-  ) {
-    console.warn(
-      'Bundler (rollup, webpack or parcel) detected in package.json. File path resoltion may not work as expected on runpkg.'
-    );
-  }
-};
+// // For now, add warning in console if popular bundler detected
+// const warnAboutBundler = pkgJSON => {
+//   if (
+//     pkgJSON.scripts instanceof Object &&
+//     Object.values(pkgJSON.scripts).some(
+//       x =>
+//         x.startsWith('rollup') ||
+//         x.startsWith('webpack') ||
+//         x.startsWith('parcel')
+//     )
+//   ) {
+//     console.warn(
+//       'Bundler (rollup, webpack or parcel) detected in package.json. File path resoltion may not work as expected on runpkg.'
+//     );
+//   }
+// };
 
-const Home = () => {
-  function reducer(state, action) {
-    switch (action.type) {
-      case 'toggleIsSearching':
-        return { ...state, isSearching: !state.isSearching };
-      case 'setIsSearching':
-        return { ...state, isSearching: action.payload };
-      case 'setRequest':
-        return {
-          ...state,
-          request: action.payload,
-          isSearching: false,
-        };
-      case 'setFile':
-        return { ...state, file: action.payload };
-      case 'setFetchError':
-        return { ...state, fetchError: action.payload };
-      case 'setVersions':
-        return { ...state, versions: action.payload };
-      case 'setDependencies':
-        return { ...state, dependencyState: action.payload };
-      default:
-        return { ...state };
-    }
-  }
+// console.log('hi');
 
-  const [state, dispatch] = react.useReducer(reducer, {
-    isSearching: false,
-    request: parseUrl(),
-    file: {},
-    fetchError: false,
-    versions: [],
-    dependencyState: {},
-  });
+// const Home = () => {
+//   function reducer(state, action) {
+//     switch (action.type) {
+//       case 'toggleIsSearching':
+//         return { ...state, isSearching: !state.isSearching };
+//       case 'setIsSearching':
+//         return { ...state, isSearching: action.payload };
+//       case 'setRequest':
+//         return {
+//           ...state,
+//           request: action.payload,
+//           isSearching: false,
+//         };
+//       case 'setFile':
+//         return { ...state, file: action.payload };
+//       case 'setFetchError':
+//         return { ...state, fetchError: action.payload };
+//       case 'setVersions':
+//         return { ...state, versions: action.payload };
+//       case 'setDependencies':
+//         return { ...state, dependencyState: action.payload };
+//       default:
+//         return { ...state };
+//     }
+//   }
 
-  react.useEffect(() => {
-    const check = e => {
-      if (e.key === 'p' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        dispatch({ type: 'toggleIsSearching' });
-      }
-      if (e.key === 'Escape')
-        dispatch({ type: 'setIsSearching', payload: false });
-    };
-    window.addEventListener('keydown', check);
-  }, []);
+//   // const [state, dispatch] = react.useReducer(reducer, {
+//   //   isSearching: false,
+//   //   request: parseUrl(),
+//   //   file: {},
+//   //   fetchError: false,
+//   //   versions: [],
+//   //   dependencyState: {},
+//   // });
 
-  // Runs once and subscribes to url changes
-  react.useEffect(() => {
-    // Rerender the app when pushState is called
-    ['pushState'].map(event => {
-      const original = window.history[event];
-      window.history[event] = function() {
-        original.apply(history, arguments);
-        dispatch({ type: 'setRequest', payload: parseUrl() });
-      };
-    });
-    // Rerender when the back and forward buttons are pressed
-    addEventListener('popstate', () =>
-      dispatch({ type: 'setRequest', payload: parseUrl() })
-    );
-  }, []);
+//   react.useEffect(() => {
+//     const check = e => {
+//       if (e.key === 'p' && (e.metaKey || e.ctrlKey)) {
+//         e.preventDefault();
+//         dispatch({ type: 'toggleIsSearching' });
+//       }
+//       if (e.key === 'Escape')
+//         dispatch({ type: 'setIsSearching', payload: false });
+//     };
+//     window.addEventListener('keydown', check);
+//   }, []);
 
-  // Whenever the URL changes then:
-  // 1. Resolve the unpkg url and file contents for the request url
-  // 2. Fetch the package.json for the requested package
-  // 3. Fetch the /?meta for the requested package
-  react.useEffect(() => {
-    // Reset any previous state
-    if (!state.request.package) {
-      dispatch({ type: 'setFile', payload: {} });
-      dispatch({ type: 'setFetchError', payload: false });
-    }
-    if (state.request.package) {
-      const { request } = state;
-      (async () => {
-        // Fetch the file contents and check for redirect
-        const { url, code } = await fetch(
-          `https://unpkg.com/${request.url}`
-        ).then(async res => ({
-          code: (await res.text()).replace(/\t/g, '  '),
-          url: res.url,
-        }));
-        // Fetch the meta data
-        const meta = await fetch(`https://unpkg.com/${request.package}/?meta`)
-          .then(res => res.json())
-          .catch(() => dispatch({ type: 'setFetchError', payload: true }));
-        // Fetch the package json
-        const pkg = await fetch(
-          `https://unpkg.com/${request.package}/package.json`
-        )
-          .then(res => res.json())
-          .catch(() => dispatch({ type: 'setFetchError', payload: true }));
+//   react.useEffect(() => {
+//     if (state.fetchError) {
+//       document.title = '404 | runpkg';
+//     } else if (state.request && state.request.package) {
+//       document.title = state.request.package + ' | runpkg';
+//     } else {
+//       document.title = 'runpkg | the package explorer';
+//     }
+//   }, [state.request.url, state.fetchError]);
 
-        if (pkg) warnAboutBundler(pkg);
-
-        // Set the new state
-        dispatch({ type: 'setFile', payload: { url, meta, pkg, code } });
-        replaceState(`?${url.replace('https://unpkg.com/', '')}`);
-        try {
-          var parser = new DOMParser();
-          const unpkgPage = await fetch(
-            `https://unpkg.com/${request.package}/`
-          ).then(async res =>
-            parser.parseFromString(await res.text(), 'text/html')
-          );
-
-          const scriptElements = unpkgPage.getElementsByTagName('script');
-
-          dispatch({
-            type: 'setVersions',
-            payload: JSON.parse(
-              `${
-                Object.values(scriptElements)
-                  .filter(x => x.innerHTML.includes('window.__DATA__'))[0]
-                  .innerHTML.split('window.__DATA__ = ')[1]
-              }`
-            ).availableVersions,
-          });
-        } catch (err) {
-          console.log('error in version parser');
-          console.log(err);
-        }
-      })();
-    }
-  }, [state.request.url]);
-
-  react.useEffect(() => {
-    if (state.fetchError) {
-      document.title = '404 | runpkg';
-    } else if (state.request && state.request.package) {
-      document.title = state.request.package + ' | runpkg';
-    } else {
-      document.title = 'runpkg | the package explorer';
-    }
-  }, [state.request.url, state.fetchError]);
-
-  return html`
-    <main className=${css`/index.css`}>
-      ${state.fetchError
-        ? NotFound
-        : state.isSearching
-        ? html`
-            <${Search} isSearching=${state.isSearching} dispatch=${dispatch} />
-          `
-        : !state.request.url
-        ? Dialog
-        : isEmpty(state.file)
-        ? null
-        : html`
-            <${Nav}
-              versions=${state.versions}
-              file=${state.file}
-              dispatch=${dispatch}
-            />
-            <${Article}
-              file=${state.file}
-              dependencyState=${state.dependencyState}
-            />
-            <${Aside} dispatch=${dispatch} file=${state.file} />
-            <${Footer} />
-          `}
-    </main>
-  `;
-};
+//   return html`
+//     <main className=${css`/index.css`}>
+//       ${state.fetchError
+//         ? NotFound
+//         : state.isSearching
+//         ? html`
+//             <${Search} isSearching=${state.isSearching} />
+//           `
+//         : !state.request.url
+//         ? Dialog
+//         : isEmpty(state.file)
+//         ? null
+//         : html`
+//             <${Nav} versions=${state.versions} file=${state.file} />
+//             <${Article}
+//               file=${state.file}
+//               dependencyState=${state.dependencyState}
+//             />
+//             <${Aside} file=${state.file} />
+//             <${Footer} />
+//           `}
+//     </main>
+//   `;
+// };
 
 react.render(
   html`
-    <${Home} />
+    <${Providers}>
+      <${Home} />
+    </${Providers}>
   `,
   document.body
 );


### PR DESCRIPTION
- [x] Moves app state (reducer) into separate context providers
- [ ] Updates all components to use new context values
- [ ] Updates URL handling to use full URL paths, rather than query parameters - to make it more inline with unpkg (and make it a lot cleaner when converting from unpkg to runpkg URLs)

(Based on top of `zeit-begone` branch for now, while that PR is unmerged) 