### PR TITLE
Editor loading state + Scroll to selected line

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -15,7 +15,9 @@ export default () => {
 
 const styles = css`
   grid-area: article;
-  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   flex: 1 0 62%;
 
   @media screen and (max-width: 800px) {

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -92,8 +92,9 @@ export default () => {
     >
       ${({ className, style, tokens, getLineProps, getTokenProps }) => html`
         <pre
-          className=${`${styles.container} ${className} ${loading &&
-            styles.loading} `}
+          className=${`${styles.container} ${className} ${
+            loading ? styles.loading : ''
+          } `}
           style=${style}
           ref=${container}
         >

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -1,4 +1,4 @@
-import { html, css } from 'https://unpkg.com/rplus-production@1.0.0';
+import { react, html, css } from 'https://unpkg.com/rplus-production@1.0.0';
 import Highlight, {
   Prism,
 } from 'https://unpkg.com/prism-react-renderer?module';
@@ -20,20 +20,55 @@ const hasImport = line =>
 
 const removeQuotes = packageName => packageName.replace(/['"]+/g, '');
 
+function usePrevious(value) {
+  const ref = react.useRef();
+  react.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}
+
 export default () => {
   const [{ code, cache, request }] = useStateValue();
   const selectedLine = getSelectedLineNumberFromUrl();
-  const { dependencies } = cache['https://unpkg.com/' + request.path] || {};
-  if (!dependencies) return null;
+  const fileData = cache['https://unpkg.com/' + request.path];
+
+  const prevCode = usePrevious(code);
+  const prevReq = usePrevious(request);
+  const prevFileData = react.useRef();
+  react.useEffect(() => {
+    prevFileData.current = fileData || prevFileData.current;
+  }, [fileData]);
+
+  let loading = false;
+
+  let codeToRender = code;
+  let deps = fileData && fileData.dependencies;
+  if (
+    (prevReq && prevReq.path !== request.path) ||
+    !(fileData && fileData.dependencies)
+  ) {
+    codeToRender = prevCode;
+    deps = prevFileData.current && prevFileData.current.dependencies;
+    loading = true;
+  }
+
+  if (!deps) {
+    return null;
+  }
   return html`
     <${Highlight}
       Prism=${Prism}
-      code=${code.slice(0, 100000)}
+      code=${codeToRender.slice(0, 100000)}
       language="javascript"
       theme=${undefined}
     >
       ${({ className, style, tokens, getLineProps, getTokenProps }) => html`
-        <pre className=${`${styles.container} ${className}`} style=${style}>
+        <pre
+          className=${`${styles.container} ${className} ${loading &&
+            styles.loading}`}
+          style=${style}
+        >
         ${tokens.map((line, i) => {
             const isImportLine = hasImport(line);
             return html`
@@ -50,7 +85,7 @@ export default () => {
                   const dep =
                     isImportLine &&
                     token.types.includes('string') &&
-                    dependencies[removeQuotes(token.content)];
+                    deps[removeQuotes(token.content)];
                   return dep
                     ? html`
                         <${Link}
@@ -79,7 +114,13 @@ const styles = {
     line-height: 138%;
     font-family: 'Inconsolata', monospace;
     padding: 2rem 1rem;
-    overflow: scroll;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  `,
+  loading: css`
+    opacity: 0.5;
+    -webkit-filter: blur(1px); /* Safari */
+    filter: blur(1px);
+    transition-delay: 0.2s;
   `,
   link: css`
     text-decoration: underline;

--- a/reset.css
+++ b/reset.css
@@ -240,3 +240,27 @@ select {
   border-right: 1rem solid transparent;
   color: rgba(255, 255, 255, 0.8);
 }
+
+::-webkit-scrollbar {
+  width: 9px;
+}
+
+::-webkit-scrollbar-track {
+  -webkit-border-radius: 1rem;
+  border-radius: 1rem;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+::-webkit-scrollbar-thumb {
+  -webkit-border-radius: 1rem;
+  border-radius: 1rem;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.4);
+}
+
+::-webkit-scrollbar-thumb:window-inactive {
+  background: rgba(0, 0, 0, 0.05);
+}


### PR DESCRIPTION
Adds a loading state for the editor for when we are fetching a new file + parsing dependencies.
Also adds scrolling to the selected line number on load.

Up for debate: Maybe we could move this logic to the context provider so all areas that use file info could have access to a loading state (i.e. the side panel could also have a loading state)