### PR TITLE
Moves code into cache and tidies up code loading state

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -4,16 +4,17 @@ import Editor from './Editor.js';
 import { useStateValue } from '../utils/globalState.js';
 
 export default () => {
-  const [{ request, code }] = useStateValue();
+  const [{ request, cache }] = useStateValue();
+  const fileData = cache['https://unpkg.com/' + request.path] || {};
   return html`
     <article className=${styles.container}>
       <h1>${request.path}</h1>
-      ${request.file && request.file.endsWith('.md')
+      ${fileData.extension === 'md'
         ? html`
             <div
               className=${styles.markdown}
               dangerouslySetInnerHTML=${{
-                __html: marked(code),
+                __html: marked(fileData.code),
               }}
             ></div>
           `

--- a/components/Main.js
+++ b/components/Main.js
@@ -71,7 +71,7 @@ export default () => {
       parseDependencies('https://unpkg.com/' + request.path).then(cache =>
         dispatch({ type: 'setCache', payload: cache })
       );
-  }, [request.file]);
+  }, [request.name, request.version, request.file]);
 
   // Fetch packages by search term
   react.useEffect(() => {

--- a/components/Main.js
+++ b/components/Main.js
@@ -10,7 +10,7 @@ const replaceState = url => history.replaceState(null, null, url);
 
 export default () => {
   const [state, dispatch] = useStateValue();
-  const { request, code, packagesSearchTerm } = state;
+  const { request, packagesSearchTerm } = state;
 
   // Update the request on user navigation
   react.useEffect(() => {
@@ -47,16 +47,6 @@ export default () => {
         .catch(console.error);
   }, [request.path]);
 
-  // Fetch the code for requested file
-  react.useEffect(() => {
-    if (request.file)
-      fetch(`https://unpkg.com/${request.path}`)
-        .then(async res =>
-          dispatch({ type: 'setCode', payload: await res.text() })
-        )
-        .catch(console.error);
-  }, [request.file, request.path]);
-
   // Fetch directory listings for requested package
   react.useEffect(() => {
     if (request.name && request.version)
@@ -77,11 +67,11 @@ export default () => {
 
   // Parse dependencies for the current code
   react.useEffect(() => {
-    if (code)
+    if (request.file)
       parseDependencies('https://unpkg.com/' + request.path).then(cache =>
         dispatch({ type: 'setCache', payload: cache })
       );
-  }, [code]);
+  }, [request.file]);
 
   // Fetch packages by search term
   react.useEffect(() => {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ const initialState = {
   dependencySearchTerm: '',
   request: parseUrl(),
   directory: {},
-  code: '',
   versions: {},
   cache: {},
   mode: 'registry',
@@ -40,8 +39,6 @@ function reducer(state, action) {
       return { ...state, request: action.payload };
     case 'setDirectory':
       return { ...state, directory: action.payload };
-    case 'setCode':
-      return { ...state, code: action.payload };
     case 'setFile':
       return { ...state, file: action.payload };
     case 'setVersions':

--- a/utils/recursiveDependencyFetch.js
+++ b/utils/recursiveDependencyFetch.js
@@ -59,6 +59,10 @@ export const parseDependencies = async path => {
   const dir = await fetch(directoriesUrl(url)).then(res => res.json());
   const pkg = await fetch(packageJsonUrl(url)).then(res => res.json());
   const files = flatten(dir.files);
+  const ext = url
+    .split('/')
+    .pop()
+    .match(/\.(.*)/);
   const dependencies = extractDependencies(code, pkg).reduce((all, entry) => {
     const packageUrl = `${UNPKG}${pkg.name}@${pkg.version}`;
     let match = makePath(url)(entry);
@@ -67,7 +71,6 @@ export const parseDependencies = async path => {
       match = version ? `${match}@${version}` : match;
     }
     if (isLocalFile(entry) && needsExtension(entry)) {
-      const ext = path.match(/\/.*\.(.*)/)[1];
       const options = files.filter(x =>
         x.match(new RegExp(`${match.replace(packageUrl, '')}(/index)?\\..*`))
       );
@@ -75,5 +78,11 @@ export const parseDependencies = async path => {
     }
     return { ...all, [entry]: match };
   }, {});
-  return { url, size: code.length, dependencies };
+  return {
+    url,
+    code,
+    dependencies,
+    size: code.length,
+    extension: ext ? ext[1] : '',
+  };
 };


### PR DESCRIPTION
Moves `code` part of state into the appropriate cache entry for the given resource (also adds `extension` too). This makes inferring if we are waiting for code to be fetched easier, thus making the logic in `Editor` much simpler.