### PR TITLE
Dont recur by default

### DIFF
--- a/utils/recursiveDependencyFetchWorker.js
+++ b/utils/recursiveDependencyFetchWorker.js
@@ -144,9 +144,9 @@ const parseDependencies = async path => {
       size: code.length,
       extension: ext ? ext[1] : '',
     });
-    Object.keys(dependencies).forEach(x =>
-      parseDependencies(dependencies[x], true)
-    );
+    // Object.keys(dependencies).forEach(x =>
+    //   parseDependencies(dependencies[x], true)
+    // );
   }
 };
 


### PR DESCRIPTION
Recursion is hard (and deep dependency fetching is expensive) so ideally we should only do it when the user has asked for it; perhaps a button on the file tab could kick it off?

Discussion and experimentation required!