### PR TITLE
Prevents error when rendering dependencies

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -123,7 +123,7 @@ export default () => {
                     isImportLine &&
                     token.types.includes('string') &&
                     fileData.dependencies[removeQuotes(token.content)];
-                  return dep
+                  return dep && typeof dep === 'string'
                     ? html`
                         <${Link}
                           href=${`/?${dep.replace('https://unpkg.com/', '')}`}


### PR DESCRIPTION
There is a case when rendering links in the editor; we check for the existence of a package in the `fileData.dependencies` object in order to determine wether to make it a link or not, the problem occurred when the package name was `toString` because objects have a `toString` method and so `fileData.dependencies['toString']` was returning the native code for that function and was thus truthy. This meant that `dep.replace` was not a function and caused a crash.

I put a check in to make sure that a string was returned from `fileData.dependencies['toString']` but if anyone has any better suggestions then I'm all ears!

Reproduction URL: `/?ramda@0.26.1/dist/ramda.min.js`
Fixed: https://deploy-preview-153--runpkg.netlify.com/?ramda@0.26.1/dist/ramda.min.js

