### PR TITLE
Extract unpkg and packument base URLs to constants.js

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -1,217 +1,218 @@
-import { html, css } from "../utils/rplus.js";
+import { UNPKG } from '../utils/constants.js';
+import { html, css } from '../utils/rplus.js';
 
-import Editor from "./Editor.js";
-import FileIcon from "./FileIcon.js";
-import PrettierIcon from "./PrettierIcon.js";
-import { useStateValue } from "../utils/globalState.js";
+import Editor from './Editor.js';
+import FileIcon from './FileIcon.js';
+import PrettierIcon from './PrettierIcon.js';
+import { useStateValue } from '../utils/globalState.js';
 
 export default () => {
-    const [{ request, cache }, dispatch] = useStateValue();
-    const fileData = cache["https://unpkg.com/" + request.path] || {};
-    return html`
-        <article className=${styles.container}>
-            ${request.path &&
-                html`
-                    <header className=${styles.header}>
-                        <h1 data-testid="package-title">
-                            ${FileIcon}
-                            <span>
-                                ${request.path}
-                            </span>
-                        </h1>
-                        <button
-                            onClick=${() => {
-                                const code = prettier.format(fileData.code, {
-                                    parser: "babylon",
-                                    plugins: prettierPlugins
-                                });
-                                dispatch({
-                                    type: "setCache",
-                                    payload: {
-                                        ["https://unpkg.com/" + request.path]: {
-                                            ...fileData,
-                                            code
-                                        }
-                                    }
-                                });
-                            }}
-                        >
-                            ${PrettierIcon}
-                            <span>Format Code</span>
-                        </button>
-                    </header>
-                `}
-            ${fileData.extension === "md"
-                ? html`
-                      <div
-                          className=${styles.markdown}
-                          dangerouslySetInnerHTML=${{
-                              __html: marked(fileData.code)
-                          }}
-                      ></div>
-                  `
-                : html`
-                      <${Editor} key="editor" />
-                  `}
-        </article>
-    `;
+  const [{ request, cache }, dispatch] = useStateValue();
+  const fileData = cache[UNPKG + request.path] || {};
+  return html`
+    <article className=${styles.container}>
+      ${request.path &&
+        html`
+          <header className=${styles.header}>
+            <h1 data-testid="package-title">
+              ${FileIcon}
+              <span>
+                ${request.path}
+              </span>
+            </h1>
+            <button
+              onClick=${() => {
+                const code = prettier.format(fileData.code, {
+                  parser: 'babylon',
+                  plugins: prettierPlugins,
+                });
+                dispatch({
+                  type: 'setCache',
+                  payload: {
+                    [UNPKG + request.path]: {
+                      ...fileData,
+                      code,
+                    },
+                  },
+                });
+              }}
+            >
+              ${PrettierIcon}
+              <span>Format Code</span>
+            </button>
+          </header>
+        `}
+      ${fileData.extension === 'md'
+        ? html`
+            <div
+              className=${styles.markdown}
+              dangerouslySetInnerHTML=${{
+                __html: marked(fileData.code),
+              }}
+            ></div>
+          `
+        : html`
+            <${Editor} key="editor" />
+          `}
+    </article>
+  `;
 };
 
 const styles = {
-    header: css`
-        display: flex;
-        align-items: center;
-        padding: 1rem 1.38rem;
-        background: rgba(0, 0, 0, 0.162);
-        > h1 {
-            display: flex;
-            align-items: center;
-            color: rgba(255, 255, 255, 0.62);
-            overflow: hidden;
-            > svg {
-                flex: none;
-                width: 1.38rem;
-                height: 1.38rem;
-                margin-right: 1rem;
-                fill: rgba(255, 255, 255, 0.38);
-            }
-            > span {
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
-        }
-        > button {
-            display: flex;
-            align-items: center;
-            background: none;
-            border: 1px solid rgba(0, 0, 0, 0.2);
-            padding: 1rem;
-            margin-left: auto;
-            color: rgba(255, 255, 255, 0.8);
-            font-size: 1rem;
-            > span {
-                white-space: nowrap;
-            }
-            > svg {
-                width: 1rem;
-                height: 1rem;
-            }
-            > * + * {
-                margin-left: 0.62rem;
-            }
-        }
-    `,
-    container: css`
-        grid-area: article;
+  header: css`
+    display: flex;
+    align-items: center;
+    padding: 1rem 1.38rem;
+    background: rgba(0, 0, 0, 0.162);
+    > h1 {
+      display: flex;
+      align-items: center;
+      color: rgba(255, 255, 255, 0.62);
+      overflow: hidden;
+      > svg {
+        flex: none;
+        width: 1.38rem;
+        height: 1.38rem;
+        margin-right: 1rem;
+        fill: rgba(255, 255, 255, 0.38);
+      }
+      > span {
         overflow: hidden;
-        flex: 1 0 62%;
-        display: flex;
-        flex-direction: column;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+    > button {
+      display: flex;
+      align-items: center;
+      background: none;
+      border: 1px solid rgba(0, 0, 0, 0.2);
+      padding: 1rem;
+      margin-left: auto;
+      color: rgba(255, 255, 255, 0.8);
+      font-size: 1rem;
+      > span {
+        white-space: nowrap;
+      }
+      > svg {
+        width: 1rem;
+        height: 1rem;
+      }
+      > * + * {
+        margin-left: 0.62rem;
+      }
+    }
+  `,
+  container: css`
+    grid-area: article;
+    overflow: hidden;
+    flex: 1 0 62%;
+    display: flex;
+    flex-direction: column;
 
-        &:empty {
-            align-items: center;
-            justify-content: center;
-            ::before {
-                font-size: 8rem;
-                content: "📦";
-                margin-bottom: 1.62rem;
-                opacity: 0.62;
-            }
+    &:empty {
+      align-items: center;
+      justify-content: center;
+      ::before {
+        font-size: 8rem;
+        content: '📦';
+        margin-bottom: 1.62rem;
+        opacity: 0.62;
+      }
 
-            ::after {
-                content: "Search for and select a package to explore its contents";
-                font-size: 1.38rem;
-                max-width: 30ex;
-                line-height: 138%;
-                text-align: center;
-                color: rgba(255, 255, 255, 0.38);
-                padding: 0 2rem;
-            }
-        }
+      ::after {
+        content: 'Search for and select a package to explore its contents';
+        font-size: 1.38rem;
+        max-width: 30ex;
+        line-height: 138%;
+        text-align: center;
+        color: rgba(255, 255, 255, 0.38);
+        padding: 0 2rem;
+      }
+    }
 
-        @media screen and (max-width: 800px) {
-            height: 62vh;
-        }
+    @media screen and (max-width: 800px) {
+      height: 62vh;
+    }
 
-        pre {
-            color: rgba(255, 255, 255, 0.9);
-        }
-    `,
-    markdown: css`
-        color: #fff;
-        line-height: 1.5;
-        line-height: 1.5;
-        word-wrap: break-word;
-        padding: 3rem 3rem 4rem;
-        width: 100%;
-        max-width: 960px;
-        margin: 0 auto;
-        overflow-y: scroll;
-        -webkit-overflow-scrolling: touch;
-        color: rgba(255, 255, 255, 0.8);
-        > * + * {
-            margin-top: 1rem;
-        }
+    pre {
+      color: rgba(255, 255, 255, 0.9);
+    }
+  `,
+  markdown: css`
+    color: #fff;
+    line-height: 1.5;
+    line-height: 1.5;
+    word-wrap: break-word;
+    padding: 3rem 3rem 4rem;
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
+    color: rgba(255, 255, 255, 0.8);
+    > * + * {
+      margin-top: 1rem;
+    }
 
-        @media screen and (max-width: 400px) {
-            padding: 2rem;
-        }
+    @media screen and (max-width: 400px) {
+      padding: 2rem;
+    }
 
-        li {
-            list-style: disc;
-            list-style-position: inside;
-        }
-        h1,
-        h2,
-        h3,
-        h4,
-        strong {
-            font-weight: bold;
-        }
-        h1 {
-            text-align: left;
-            font-size: 2rem;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-            padding-bottom: 1rem;
-        }
-        h2 {
-            font-size: 1.62rem;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-            padding-bottom: 0.62rem;
-            margin-bottom: 1rem;
-        }
-        h3 {
-            font-size: 1rem;
-            border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-            padding-bottom: 0.62rem;
-            margin-bottom: 1rem;
-        }
-        img {
-            display: block;
-            max-width: 100%;
-        }
-        pre {
-            background: rgba(0, 0, 0, 0.2);
-            padding: 1rem;
-            border-radius: 0.38rem;
-            overflow-x: scroll;
-        }
+    li {
+      list-style: disc;
+      list-style-position: inside;
+    }
+    h1,
+    h2,
+    h3,
+    h4,
+    strong {
+      font-weight: bold;
+    }
+    h1 {
+      text-align: left;
+      font-size: 2rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+      padding-bottom: 1rem;
+    }
+    h2 {
+      font-size: 1.62rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+      padding-bottom: 0.62rem;
+      margin-bottom: 1rem;
+    }
+    h3 {
+      font-size: 1rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+      padding-bottom: 0.62rem;
+      margin-bottom: 1rem;
+    }
+    img {
+      display: block;
+      max-width: 100%;
+    }
+    pre {
+      background: rgba(0, 0, 0, 0.2);
+      padding: 1rem;
+      border-radius: 0.38rem;
+      overflow-x: scroll;
+    }
 
-        a {
-            display: inline-block;
-            color: #f8b1f1;
-            margin-top: 0;
-        }
-        table {
-            border-collapse: collapse;
-            color: inherit;
-            td,
-            th,
-            tr {
-                border: 1px solid rgba(255, 255, 255, 0.38);
-                padding: 0.62rem;
-            }
-        }
-    `
+    a {
+      display: inline-block;
+      color: #f8b1f1;
+      margin-top: 0;
+    }
+    table {
+      border-collapse: collapse;
+      color: inherit;
+      td,
+      th,
+      tr {
+        border: 1px solid rgba(255, 255, 255, 0.38);
+        padding: 0.62rem;
+      }
+    }
+  `,
 };

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -1,4 +1,5 @@
 import { react, html, css } from '../utils/rplus.js';
+import { UNPKG } from '../utils/constants.js';
 import Highlight, { Prism } from 'prism-react-renderer';
 import { useStateValue } from '../utils/globalState.js';
 import Link from './Link.js';
@@ -62,8 +63,6 @@ const languages = {
   yml: 'yaml',
 };
 
-const UNPKG = 'https://unpkg.com/';
-
 export default () => {
   const [{ cache, request }] = useStateValue();
   const selectedLine = getSelectedLineNumberFromUrl();
@@ -126,7 +125,7 @@ export default () => {
                   return dep && typeof dep === 'string'
                     ? html`
                         <${Link}
-                          href=${`/?${dep.replace('https://unpkg.com/', '')}`}
+                          href=${`/?${dep.replace(UNPKG, '')}`}
                           className=${styles.link}
                         >
                           <span ...${getTokenProps({ token })} />

--- a/components/FileOverview.js
+++ b/components/FileOverview.js
@@ -2,6 +2,7 @@ import { css, html } from '../utils/rplus.js';
 import Link from './Link.js';
 import formatBytes from '../utils/formatBytes.js';
 import { useStateValue } from '../utils/globalState.js';
+import { UNPKG } from '../utils/constants.js';
 import FileIcon from './FileIcon.js';
 import PackageIcon from './PackageIcon.js';
 import { SearchInput } from './SearchInput.js';
@@ -17,9 +18,9 @@ const FileList = ({ title, files, packageName, filter }) => html`
         url.match(filter) &&
         html`
           <li key=${key} data-test="Item">
-            <${Link} href=${url.replace('https://unpkg.com/', '/?')}>
+            <${Link} href=${url.replace(UNPKG, '/?')}>
               ${url.includes(packageName) ? FileIcon : PackageIcon}
-              ${url.replace(`https://unpkg.com/`, '').replace(packageName, '')}
+              ${url.replace(UNPKG, '').replace(packageName, '')}
             <//>
           </li>
         `
@@ -29,7 +30,7 @@ const FileList = ({ title, files, packageName, filter }) => html`
 
 export const FileOverview = () => {
   const [{ request, cache, dependencySearchTerm }, dispatch] = useStateValue();
-  const file = cache['https://unpkg.com/' + request.path];
+  const file = cache[UNPKG + request.path];
   return (
     !!file &&
     html`

--- a/components/Main.js
+++ b/components/Main.js
@@ -1,3 +1,4 @@
+import { UNPKG, PACKUMENT } from '../utils/constants.js';
 import { react, html, css } from '../utils/rplus.js';
 import { useStateValue } from '../utils/globalState.js';
 import { parseUrl } from '../utils/parseUrl.js';
@@ -40,12 +41,10 @@ export default () => {
   // Resolve full path for incomplete urls
   react.useEffect(() => {
     if (request.name && (!request.version || !request.file))
-      fetch(`https://unpkg.com/${request.path}`)
+      fetch(UNPKG + request.path)
         .then(({ url }) => {
           dispatch({ type: 'setRequest', payload: parseUrl(url) });
-          replaceState(
-            `/?${url.replace('https://unpkg.com/', '')}${location.hash}`
-          );
+          replaceState(`/?${url.replace(UNPKG, '')}${location.hash}`);
         })
         .catch(console.error);
   }, [request.path]);
@@ -53,7 +52,7 @@ export default () => {
   // Fetch directory listings for requested package
   react.useEffect(() => {
     if (request.name && request.version)
-      fetch(`https://unpkg.com/${request.name}@${request.version}/?meta`)
+      fetch(`${UNPKG}${request.name}@${request.version}/?meta`)
         .then(res => res.json())
         .then(res => dispatch({ type: 'setDirectory', payload: res }))
         .catch(console.error);
@@ -62,7 +61,7 @@ export default () => {
   // Fetch package meta data for all versions
   react.useEffect(() => {
     if (request.name)
-      fetch(`https://registry.npmjs.cf/${request.name}/`)
+      fetch(`${PACKUMENT}/${request.name}/`)
         .then(res => res.json())
         .then(json => {
           dispatch({ type: 'setVersions', payload: json.versions });
@@ -73,8 +72,8 @@ export default () => {
 
   // Parse dependencies for the current code
   react.useEffect(() => {
-    if (request.file && !cache['https://unpkg.com/' + request.path])
-      worker.postMessage('https://unpkg.com/' + request.path);
+    if (request.file && !cache[UNPKG + request.path])
+      worker.postMessage(UNPKG + request.path);
   }, [request.path]);
 
   // Fetch packages by search term

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-nested-callbacks */
-const cacheName = 'www.runpkg.com';
+const cacheName = 'www.unpkg.com';
 
 self.addEventListener('activate', () => {
   console.log('service worker activated');

--- a/tests/utils/parseUrl.test.js
+++ b/tests/utils/parseUrl.test.js
@@ -1,12 +1,13 @@
 require = require('esm')(module);
 
 const parseUrlFile = require('../../utils/parseUrl');
+const { UNPKG } = require('../../utils/constants');
 
 const parseUrl = parseUrlFile.parseUrl;
 
 describe('parseUrl', () => {
   it('parses non beta package', () => {
-    expect(parseUrl('https://unpkg.com/pkg-dash@1.0.0/extra.js')).toEqual({
+    expect(parseUrl(UNPKG + 'pkg-dash@1.0.0/extra.js')).toEqual({
       name: 'pkg-dash',
       version: '1.0.0',
       path: 'pkg-dash@1.0.0/extra.js',
@@ -15,9 +16,7 @@ describe('parseUrl', () => {
     });
   });
   it('parses beta package', () => {
-    expect(
-      parseUrl('https://unpkg.com/pkg-dash@1.0.0-beta.1/extra.js')
-    ).toEqual({
+    expect(parseUrl(UNPKG + 'pkg-dash@1.0.0-beta.1/extra.js')).toEqual({
       name: 'pkg-dash',
       version: '1.0.0-beta.1',
       path: 'pkg-dash@1.0.0-beta.1/extra.js',
@@ -27,7 +26,7 @@ describe('parseUrl', () => {
   });
   it('parses beta package with file a directory down', () => {
     expect(
-      parseUrl('https://unpkg.com/fast-deep-equal@3.0.0-beta.1/es6/index.js')
+      parseUrl(UNPKG + 'fast-deep-equal@3.0.0-beta.1/es6/index.js')
     ).toEqual({
       file: 'index.js',
       name: 'fast-deep-equal',
@@ -37,7 +36,7 @@ describe('parseUrl', () => {
     });
   });
   it('parses scoped non-beta package', () => {
-    expect(parseUrl('https://unpkg.com/@scope/pkg@1.0.0/index.js')).toEqual({
+    expect(parseUrl(UNPKG + '@scope/pkg@1.0.0/index.js')).toEqual({
       file: 'index.js',
       name: '@scope/pkg',
       path: '@scope/pkg@1.0.0/index.js',
@@ -46,20 +45,16 @@ describe('parseUrl', () => {
     });
   });
   it('parses scoped non-beta package with file a directory down', () => {
-    expect(parseUrl('https://unpkg.com/@scope/pkg@1.0.0/es6/index.js')).toEqual(
-      {
-        file: 'index.js',
-        name: '@scope/pkg',
-        path: '@scope/pkg@1.0.0/es6/index.js',
-        directory: 'es6',
-        version: '1.0.0',
-      }
-    );
+    expect(parseUrl(UNPKG + '@scope/pkg@1.0.0/es6/index.js')).toEqual({
+      file: 'index.js',
+      name: '@scope/pkg',
+      path: '@scope/pkg@1.0.0/es6/index.js',
+      directory: 'es6',
+      version: '1.0.0',
+    });
   });
   it('parses scoped beta package', () => {
-    expect(
-      parseUrl('https://unpkg.com/@scope/pkg@1.0.0-beta.1/index.js')
-    ).toEqual({
+    expect(parseUrl(UNPKG + '@scope/pkg@1.0.0-beta.1/index.js')).toEqual({
       file: 'index.js',
       name: '@scope/pkg',
       path: '@scope/pkg@1.0.0-beta.1/index.js',
@@ -68,21 +63,21 @@ describe('parseUrl', () => {
     });
   });
   it('keys are returned null if not available', () => {
-    expect(parseUrl('https://unpkg.com/')).toEqual({
+    expect(parseUrl(UNPKG + '')).toEqual({
       file: null,
       name: null,
       path: null,
       directory: null,
       version: null,
     });
-    expect(parseUrl('https://unpkg.com/@scope/pkg')).toEqual({
+    expect(parseUrl(UNPKG + '@scope/pkg')).toEqual({
       file: null,
       name: '@scope/pkg',
       path: '@scope/pkg',
       directory: null,
       version: null,
     });
-    expect(parseUrl('https://unpkg.com/@scope/pkg@1.0.0-beta.1')).toEqual({
+    expect(parseUrl(UNPKG + '@scope/pkg@1.0.0-beta.1')).toEqual({
       file: null,
       name: '@scope/pkg',
       path: '@scope/pkg@1.0.0-beta.1',

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,2 @@
+export const UNPKG = 'https://unpkg.com/';
+export const PACKUMENT = 'https://registry.npmjs.cf/';

--- a/utils/parseUrl.js
+++ b/utils/parseUrl.js
@@ -1,7 +1,7 @@
 const parseUrl = (url = window.location.search.slice(1).replace(/\/$/, '')) => {
   const parts = url
     .trim()
-    .replace('https://unpkg.com', '')
+    .replace('https://unpkg.com/', '')
     .split('/')
     .map(part => part.trim())
     .filter(Boolean);

--- a/utils/recursiveDependencyFetchWorker.js
+++ b/utils/recursiveDependencyFetchWorker.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-eval */
-const UNPKG = 'https://unpkg.com/';
 
 const fileNameRegEx = /\/[^\/@]+[\.][^\/]+$/;
 
@@ -10,6 +9,10 @@ const getParseUrl = () =>
     .then(x =>
       x.replace(/\s*export {[^}]+\};/g, '').replace(/^const\s[^=]+=/, '')
     );
+
+// This isn't imported from constants.js since otherwise we're importing
+// (see abive for webworker note)
+const UNPKG = 'https://unpkg.com/';
 
 // Handles paths like "../../some-file.js"
 const handleDoubleDot = (pathEnd, base) => {
@@ -148,10 +151,11 @@ const parseDependencies = async path => {
 
 self.onmessage = async event => {
   const { data } = event;
-  await setupParseUrl();
   try {
+    await setupParseUrl();
     await parseDependencies(data);
   } catch (e) {
+    console.error(e);
     // This is a truly awful hack to get around random CORS errors
     parseDependencies(data);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
-  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
-  dependencies:
-    "@babel/highlight" "^7.0.0"
-
-"@babel/code-frame@^7.5.5":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
   integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
@@ -685,11 +678,6 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
   integrity sha1-MvxLn82vhF/N9+c7uXysImHwqwo=
 
-camelcase@^5.0.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
-  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
@@ -786,15 +774,6 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-cliui@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
-  integrity sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==
-  dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -832,12 +811,7 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
-commander@^2.14.1, commander@^2.9.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
-
-commander@~2.20.3:
+commander@^2.14.1, commander@^2.9.0, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -866,21 +840,6 @@ concat-stream@1.6.2:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
-
-concurrently@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-5.0.0.tgz#99c7567d009411fbdc98299d553c4b99a978612c"
-  integrity sha512-1yDvK8mduTIdxIxV9C60KoiOySUl/lfekpdbI+U5GXaPrgdffEavFa9QZB3vh68oWOpbCC+TuvxXV9YRPMvUrA==
-  dependencies:
-    chalk "^2.4.2"
-    date-fns "^2.0.1"
-    lodash "^4.17.15"
-    read-pkg "^4.0.1"
-    rxjs "^6.5.2"
-    spawn-command "^0.0.2-1"
-    supports-color "^4.5.0"
-    tree-kill "^1.2.1"
-    yargs "^12.0.5"
 
 contains-path@^0.1.0:
   version "0.1.0"
@@ -997,11 +956,6 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-date-fns@^2.0.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.8.1.tgz#2109362ccb6c87c3ca011e9e31f702bc09e4123b"
-  integrity sha512-EL/C8IHvYRwAHYgFRse4MGAPSqlJVlOrhVYZ75iQBKrnv+ZedmYsgwH3t+BCDuZDXpoo07+q9j4qgSSOa7irJg==
-
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1023,7 +977,7 @@ debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-decamelize@^1.1.1, decamelize@^1.2.0:
+decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -1169,19 +1123,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.11.0, es-abstract@^1.7.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
-  integrity sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
-  dependencies:
-    es-to-primitive "^1.2.0"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    is-callable "^1.1.4"
-    is-regex "^1.0.4"
-    object-keys "^1.0.12"
-
-es-abstract@^1.4.3:
+es-abstract@^1.11.0, es-abstract@^1.4.3, es-abstract@^1.7.0:
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.16.2.tgz#4e874331645e9925edef141e74fc4bd144669d34"
   integrity sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==
@@ -1196,15 +1138,6 @@ es-abstract@^1.4.3:
     object-keys "^1.1.1"
     string.prototype.trimleft "^2.1.0"
     string.prototype.trimright "^2.1.0"
-
-es-to-primitive@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
-  integrity sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
-  dependencies:
-    is-callable "^1.1.4"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.2"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -1400,12 +1333,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
-  integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
-
-estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -1567,7 +1495,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
+fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -1834,34 +1762,10 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.1:
+glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.2, glob@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1877,15 +1781,10 @@ global-dirs@^0.1.0:
   dependencies:
     ini "^1.3.4"
 
-globals@^11.1.0:
+globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-
-globals@^11.7.0:
-  version "11.11.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
-  integrity sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==
 
 globals@^9.18.0:
   version "9.18.0"
@@ -1903,15 +1802,10 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
-
-graceful-fs@^4.1.2:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -1954,22 +1848,12 @@ has-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
   integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
 
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
-  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
-has-symbols@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
-  integrity sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=
-
-has-symbols@^1.0.1:
+has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -2110,12 +1994,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
-
-inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2155,11 +2034,6 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
-
-invert-kv@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
-  integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -2933,13 +2807,6 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lcid@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
-  integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
-  dependencies:
-    invert-kv "^2.0.0"
-
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
@@ -3146,15 +3013,10 @@ lodash.upperfirst@4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
-lodash@4.17.15, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@4.17.15, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.10, lodash@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log-symbols@2.2.0, log-symbols@^2.2.0:
   version "2.2.0"
@@ -3201,13 +3063,6 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-map-age-cleaner@^0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
-  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
-  dependencies:
-    p-defer "^1.0.0"
-
 map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -3231,15 +3086,6 @@ math-random@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
   integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
-
-mem@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
-  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
-  dependencies:
-    map-age-cleaner "^0.1.1"
-    mimic-fn "^2.0.0"
-    p-is-promise "^2.0.0"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -3305,11 +3151,6 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
-
-mimic-fn@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
-  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
@@ -3569,7 +3410,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.1:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
@@ -3580,18 +3421,6 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
-
-optionator@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
-  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
-  dependencies:
-    deep-is "~0.1.3"
-    fast-levenshtein "~2.0.4"
-    levn "~0.3.0"
-    prelude-ls "~1.1.2"
-    type-check "~0.3.2"
-    wordwrap "~1.0.0"
 
 ora@^0.2.3:
   version "0.2.3"
@@ -3615,34 +3444,15 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-locale@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-3.1.0.tgz#a802a6ee17f24c10483ab9935719cef4ed16bf1a"
-  integrity sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==
-  dependencies:
-    execa "^1.0.0"
-    lcid "^2.0.0"
-    mem "^4.0.0"
-
 os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
-p-defer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
-  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
-
-p-is-promise@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
-  integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -3909,12 +3719,7 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
-psl@^1.1.24:
-  version "1.1.31"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
-  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
-
-psl@^1.1.28:
+psl@^1.1.24, psl@^1.1.28:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
   integrity sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
@@ -4013,15 +3818,6 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
-
-read-pkg@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
-  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
-  dependencies:
-    normalize-package-data "^2.3.2"
-    parse-json "^4.0.0"
-    pify "^3.0.0"
 
 read-pkg@^5.1.1:
   version "5.1.1"
@@ -4161,14 +3957,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.10.0, resolve@^1.5.0, resolve@^1.9.0:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
-  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.12.0, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.9.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -4196,14 +3985,14 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@2.6.3, rimraf@^2.2.8:
+rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@^2.2.8, rimraf@^2.6.1, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -4233,13 +4022,6 @@ rxjs@^6.3.3, rxjs@^6.4.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"
   integrity sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.3.tgz#510e26317f4db91a7eb1de77d9dd9ba0a4899a3a"
-  integrity sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==
   dependencies:
     tslib "^1.9.0"
 
@@ -4283,12 +4065,7 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.5.1:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
-
-semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.5.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -4444,11 +4221,6 @@ source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-spawn-command@^0.0.2-1:
-  version "0.0.2-1"
-  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
-  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
-
 spdx-correct@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
@@ -4541,7 +4313,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -4660,13 +4432,6 @@ supports-color@^3.1.2:
   integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
   dependencies:
     has-flag "^1.0.0"
-
-supports-color@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
-  integrity sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=
-  dependencies:
-    has-flag "^2.0.0"
 
 symbol-observable@1.0.1:
   version "1.0.1"
@@ -4808,11 +4573,6 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
-
-tree-kill@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
-  integrity sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -4988,11 +4748,6 @@ which-module@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
   integrity sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=
 
-which-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
-
 which@^1.2.10, which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -5009,11 +4764,6 @@ wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
   integrity sha1-o9XabNXAvAAI03I0u68b7WMFkQc=
-
-wordwrap@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 worker-farm@^1.3.1:
   version "1.7.0"
@@ -5060,43 +4810,12 @@ y18n@^3.2.1:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
   integrity sha1-bRX7qITAhnnA136I53WegR4H+kE=
 
-"y18n@^3.2.1 || ^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
-
-yargs-parser@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
-  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
 yargs-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-5.0.0.tgz#275ecf0d7ffe05c77e64e7c86e4cd94bf0e1228a"
   integrity sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=
   dependencies:
     camelcase "^3.0.0"
-
-yargs@^12.0.5:
-  version "12.0.5"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
-  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.2.0"
-    find-up "^3.0.0"
-    get-caller-file "^1.0.1"
-    os-locale "^3.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1 || ^4.0.0"
-    yargs-parser "^11.1.1"
 
 yargs@^7.0.2:
   version "7.1.0"


### PR DESCRIPTION
This makes it a little easier to change the unpkg or packument URLs
globally. It doesn't change them however in:
- serviceWorker.js
- utils/parseUrl.js
- utils/recursiveDependencyFetchWorker.js
Since those may also be executed in a worker, which don't currently
support imports.

Seems that the `yarn.lock` file was out-of-date and had some duplicates btw.
Also this seems to run prettier on a couple of files, but happy to revert if necessary.