### PR TITLE
Experiment: Convert to using bunpkg.dev

### DIFF
--- a/components/Main.js
+++ b/components/Main.js
@@ -64,7 +64,7 @@ export default () => {
       fetch(`${PACKUMENT}/${request.name}/`)
         .then(res => res.json())
         .then(json => {
-          dispatch({ type: 'setVersions', payload: json.versions });
+          dispatch({ type: 'setInfo', payload: json });
           dispatch({ type: 'setMode', payload: 'package' });
         })
         .catch(console.error);

--- a/components/PackageOverview.js
+++ b/components/PackageOverview.js
@@ -70,7 +70,8 @@ export const PackageOverview = () => {
     dispatch,
   ] = useStateValue();
   const { version } = request;
-  if (!info || !info.time[version] || !directory.files) return null;
+  if (!info || !info.time || !info.time[version] || !directory.files)
+    return null;
   const { name, description } = info;
   const handleVersionChange = v => pushState(`?${name}@${v}`);
   const VersionOption = x =>

--- a/components/PackageOverview.js
+++ b/components/PackageOverview.js
@@ -23,7 +23,7 @@ const File = ({ packageName, packageVersion, meta }) =>
       href=${`/?${packageName}@${packageVersion}${meta.path}`}
       className=${styles.item}
     >
-      <span>${FileIcon} ${meta.path.split('/').pop()}</span>
+      <span>${FileIcon} ${meta.name}</span>
       <small>${formatBytes(meta.size)}</small>
     <//>
   `;
@@ -44,7 +44,7 @@ const Node = ({ meta, packageName, packageVersion }) => {
             <div className=${styles.item}>
               <span>
                 ${FolderIcon}
-                <strong>${meta.path.split('/').pop()}</strong>
+                <strong>${meta.name}</strong>
               </span>
               <small>${meta.files.length} Files</small>
             </div>
@@ -66,11 +66,12 @@ const Node = ({ meta, packageName, packageVersion }) => {
 
 export const PackageOverview = () => {
   const [
-    { versions, request, directory, fileSearchTerm },
+    { info, request, directory, fileSearchTerm },
     dispatch,
   ] = useStateValue();
-  if (!versions[request.version] || !directory.files) return null;
-  const { name, version, description } = versions[request.version];
+  const { version } = request;
+  if (!info || !info.time[version] || !directory.files) return null;
+  const { name, description } = info;
   const handleVersionChange = v => pushState(`?${name}@${v}`);
   const VersionOption = x =>
     html`
@@ -101,7 +102,7 @@ export const PackageOverview = () => {
       value=${version}
       onChange=${e => handleVersionChange(e.target.value)}
     >
-      ${Object.keys(versions).map(VersionOption)}</select
+      ${info.versions.map(VersionOption)}</select
     >
     ${fileSearchTerm
       ? html`

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const initialState = {
   dependencySearchTerm: '',
   request: parseUrl(),
   directory: {},
-  versions: {},
+  info: {},
   cache: {},
   mode: 'registry',
 };
@@ -41,8 +41,8 @@ function reducer(state, action) {
       return { ...state, directory: action.payload };
     case 'setFile':
       return { ...state, file: action.payload };
-    case 'setVersions':
-      return { ...state, versions: action.payload };
+    case 'setInfo':
+      return { ...state, info: action.payload };
     case 'setCache':
       return {
         ...state,

--- a/serviceWorker.js
+++ b/serviceWorker.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-nested-callbacks */
-const cacheName = 'www.unpkg.com';
+const cacheName = 'www.bunpkg.dev';
 
 self.addEventListener('activate', () => {
   console.log('service worker activated');
@@ -7,8 +7,8 @@ self.addEventListener('activate', () => {
 
 self.addEventListener('fetch', event => {
   if (
-    event.request.url.includes('https://unpkg') &&
-    !event.request.referrer.includes('https://unpkg.com/')
+    event.request.url.includes('https://bunpkg') &&
+    !event.request.referrer.includes('https://bunpkg.dev/')
   ) {
     event.respondWith(
       caches.open(cacheName).then(cache =>

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,2 +1,2 @@
-export const UNPKG = 'https://unpkg.com/';
-export const PACKUMENT = 'https://registry.npmjs.cf/';
+export const UNPKG = 'https://bunpkg.dev/n/';
+export const PACKUMENT = 'https://bunpkg.dev/i';

--- a/utils/parseUrl.js
+++ b/utils/parseUrl.js
@@ -1,7 +1,7 @@
 const parseUrl = (url = window.location.search.slice(1).replace(/\/$/, '')) => {
   const parts = url
     .trim()
-    .replace('https://unpkg.com/', '')
+    .replace('https://bunpkg.dev/n/', '')
     .split('/')
     .map(part => part.trim())
     .filter(Boolean);

--- a/utils/recursiveDependencyFetchWorker.js
+++ b/utils/recursiveDependencyFetchWorker.js
@@ -12,7 +12,7 @@ const getParseUrl = () =>
 
 // This isn't imported from constants.js since otherwise we're importing
 // (see abive for webworker note)
-const UNPKG = 'https://unpkg.com/';
+const UNPKG = 'https://bunpkg.dev/n/';
 
 // Handles paths like "../../some-file.js"
 const handleDoubleDot = (pathEnd, base) => {


### PR DESCRIPTION
This branch is just an experiment branch based off of `chore/extract-unpkg-constant` and converts stuff over to `bunpkg.dev`.

In some cases changes had to be made. The `setVersions` action is now `setInfo` since the data has a slightly different structure. The same goes for the `?meta` data which doesn't have full `url` info but does come with a `name` field (one unnecessary field gone, a useful one added :+1:)