### PR TITLE
Less specific import/export regex and smarter option choosing

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -9,13 +9,6 @@ const getSelectedLineNumberFromUrl = () =>
 const handleLineNumberClick = lineNo =>
   history.pushState(null, null, `#${lineNo}`);
 
-const hasImport = line =>
-  line.some(
-    token =>
-      token.types.includes('module') ||
-      (token.types.includes('function') && token.content === 'require')
-  );
-
 const removeQuotes = packageName => packageName.replace(/['"]+/g, '');
 
 function useLastGoodState(value) {
@@ -106,7 +99,6 @@ export default () => {
           >
           <code className=${styles.code}>
         ${tokens.map((line, i) => {
-            const isImportLine = hasImport(line);
             return html`
               <div
                 ...${getLineProps({ line, key: i })}
@@ -120,8 +112,6 @@ export default () => {
                 >
                 ${line.map(token => {
                   const dep =
-                    isImportLine &&
-                    token.types.includes('string') &&
                     fileData.dependencies[removeQuotes(token.content)];
                   return dep && typeof dep === 'string'
                     ? html`

--- a/utils/recursiveDependencyFetchWorker.js
+++ b/utils/recursiveDependencyFetchWorker.js
@@ -48,7 +48,7 @@ const isListedInDependencies = (pkgName, pkgJson) =>
 const stripComments = str =>
   str.replace(/^[\t ]*\/\*(.|\r|\n)*?\*\/|^[\t ]*\/\/.*/gm, '');
 
-const importExportRegex = /^(import|export).*(from)[ \n]+['"](.*?)['"];?$/;
+const importExportRegex = /(from|import)[ \n]?['"](.*?)['"];?/;
 const requireRegex = /(require\(['"])([^)\n\r]*)(['"]\))/;
 
 const packageJsonUrl = (name, version) => {
@@ -68,7 +68,7 @@ const flatten = arr =>
 const extractDependencies = (input, packageJson) => {
   const code = stripComments(input).slice(0, 100000);
   const imports = (code.match(new RegExp(importExportRegex, 'gm')) || []).map(
-    x => x.match(new RegExp(importExportRegex))[3]
+    x => x.match(new RegExp(importExportRegex))[2]
   );
   const requires = (code.match(new RegExp(requireRegex, 'gm')) || []).map(
     x => x.match(new RegExp(requireRegex))[2]
@@ -132,7 +132,11 @@ const parseDependencies = async path => {
         const options = files.filter(x =>
           x.match(new RegExp(`${match.replace(packageUrl, '')}(/index)?\\..*`))
         );
-        match = packageUrl + (options.find(x => x.endsWith(ext)) || options[0]);
+        match =
+          packageUrl +
+          (options
+            .sort((a, b) => a.length - b.length || a.localeCompare(b))
+            .find(x => x.endsWith(ext[0])) || options[0]);
       }
       return { ...all, [entry]: match };
     }, {});


### PR DESCRIPTION
Fixes a few scenarios where dependencies were not being detected or highlighted. Including:

https://deploy-preview-166--runpkg.netlify.com/

- Export statements like `export * from "./somewhere"` [example](https://runpkg.com/?@urql/exchange-graphcache@1.2.2/src/index.ts) -> [fix](https://deploy-preview-166--runpkg.netlify.com/?@urql/exchange-graphcache@1.2.2/src/index.ts)
- Import statements with no space like `import"./something.js"` [example](https://runpkg.com/?es-react@16.11.0/index.js) -> [fix](https://deploy-preview-166--runpkg.netlify.com/?es-react@16.11.0/index.js)
- Multiline import/export after destructuring [example](https://runpkg.com/?@urql/exchange-graphcache@1.2.2/src/operations/query.ts) -> [fix](https://deploy-preview-166--runpkg.netlify.com/?@urql/exchange-graphcache@1.2.2/src/operations/query.ts)

There was also some logic changed that makes runpkg choose the shorter file path out of any two potential options for extension-less dependencies.

- Chooses file with `.ts` over `.test.ts`