### PR TITLE
Add empty view without search terms

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -113,9 +113,9 @@ const styles = {
     }
   `,
   container: css`
-    grid-area: article;
     overflow: hidden;
     flex: 1 0 62%;
+    min-height: 100vh;
     display: flex;
     flex-direction: column;
 
@@ -128,6 +128,7 @@ const styles = {
     }
   `,
   welcome: css`
+    flex-grow: 1;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -136,7 +137,6 @@ const styles = {
     width: 100%;
     height: 100%;
     color: rgba(255, 255, 255, 0.62);
-    flex: none;
     svg:first-child {
       position: absolute;
       top: 2rem;

--- a/components/Main.js
+++ b/components/Main.js
@@ -80,6 +80,10 @@ export default () => {
 
   // Fetch packages by search term
   react.useEffect(() => {
+    if (!packagesSearchTerm) {
+      return dispatch({ type: 'setPackages', payload: [] });
+    }
+
     fetch(
       `https://api.npms.io/v2/search/suggestions?size=10&q=${packagesSearchTerm ||
         'lodash-es'}`
@@ -102,17 +106,19 @@ const styles = css`
   min-height: 100vh;
   overflow: auto;
   background: #2f3138;
+
   @media screen and (min-width: 800px) {
-    display: grid;
-    grid-template-columns: 1fr 25rem;
-    grid-template-areas: 'article nav';
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
     overflow: hidden;
     height: 100vh;
   }
+
   @media screen and (min-width: 1000px) {
-    display: grid;
-    grid-template-areas: 'article nav';
-    grid-template-columns: 1fr 30rem;
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
     overflow: hidden;
     height: 100vh;
   }

--- a/components/Main.js
+++ b/components/Main.js
@@ -103,7 +103,6 @@ export default () => {
 
 const styles = css`
   width: 100%;
-  min-height: 100vh;
   overflow: auto;
   background: #2f3138;
 

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -77,11 +77,10 @@ const styles = css`
 `;
 
 const compactStyles = css`
-  margin: 1rem;
-  border-radius: 0.5rem;
-  box-shadow: 3px 2px 4px 1px rgba(10, 10, 10, 0.05);
-
   @media screen and (min-width: 800px) {
+    margin: 1rem;
+    border-radius: 0.5rem;
+    box-shadow: 3px 2px 4px 1px rgba(10, 10, 10, 0.05);
     height: auto;
   }
 `;

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -6,31 +6,45 @@ import { FileOverview } from './FileOverview.js';
 import { useStateValue } from '../utils/globalState.js';
 
 export default () => {
-  const [{ mode }, dispatch] = useStateValue();
-  const modeOptions = {
-    registry: mode === 'registry',
-    package: mode === 'package',
-    file: mode === 'file',
-  };
+  const [state, dispatch] = useStateValue();
+  const isCompact = !state.packagesSearchTerm && !state.request.name;
+
+  const modeOptions = !state.request.name
+    ? {
+        registry: true,
+      }
+    : {
+        registry: state.mode === 'registry',
+        package: state.mode === 'package',
+        file: state.mode === 'file',
+      };
+
+  let children = null;
+  switch (state.mode) {
+    case 'package':
+      children = html`
+        <${PackageOverview} />
+      `;
+      break;
+    case 'registry':
+      children = html`
+        <${RegistryOverview} />
+      `;
+      break;
+    case 'file':
+      children = html`
+        <${FileOverview} />
+      `;
+      break;
+  }
+
   return html`
-    <nav className=${styles}>
+    <nav className=${isCompact ? `${styles} ${compactStyles}` : styles}>
       <${RadioGroup}
         options=${modeOptions}
         onClick=${val => dispatch({ type: 'setMode', payload: val })}
       />
-      ${mode === 'package'
-        ? html`
-            <${PackageOverview} />
-          `
-        : mode === 'registry'
-        ? html`
-            <${RegistryOverview} />
-          `
-        : mode === 'file'
-        ? html`
-            <${FileOverview} />
-          `
-        : null}
+      ${children}
     </nav>
   `;
 };
@@ -42,6 +56,10 @@ const styles = css`
   color: #fff;
   padding: 2rem;
   overflow-x: hidden;
+  box-shadow: none;
+  transition-property: margin, border-radius, height, box-shadow;
+  transition-duration: 0.6s;
+
   > * + * {
     margin-top: 1.38rem;
   }
@@ -55,5 +73,15 @@ const styles = css`
     > * + * {
       margin-top: 1rem;
     }
+  }
+`;
+
+const compactStyles = css`
+  margin: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 3px 2px 4px 1px rgba(10, 10, 10, 0.05);
+
+  @media screen and (min-width: 800px) {
+    height: auto;
   }
 `;

--- a/components/RegistryOverview.js
+++ b/components/RegistryOverview.js
@@ -16,9 +16,18 @@ export const RegistryOverview = () => {
         onChange=${val =>
           dispatch({ type: 'setPackagesSearchTerm', payload: val })}
       />
-      <ul className=${styles.list} key=${packagesSearchTerm}>
-        ${packages.map(Package)}
-      </ul>
+      ${!packages.length &&
+        packagesSearchTerm &&
+        html`
+          <h2>No packages found</h2>
+        `}
+      ${packages.length
+        ? html`
+            <ul className=${styles.list} key=${packagesSearchTerm}>
+              ${packages.map(Package)}
+            </ul>
+          `
+        : null}
     </div>
   `;
 };

--- a/index.js
+++ b/index.js
@@ -11,12 +11,13 @@ if ('serviceWorker' in navigator) {
     .catch(err => console.log(err));
 }
 
+const request = parseUrl();
 const initialState = {
   packages: [],
-  packagesSearchTerm: '',
+  packagesSearchTerm: request.name || '',
   fileSearchTerm: '',
   dependencySearchTerm: '',
-  request: parseUrl(),
+  request,
   directory: {},
   versions: {},
   cache: {},


### PR DESCRIPTION
Adds an empty state (no package welcome view) without showing any search terms by compacting the navigation bar. Still have to test this on mobile.