### PR TITLE
Add CONTRIBUTING doc and include CoC > #174 #138

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing
+
+Thank you for looking into contributing to runpkg!
+
+## Setup
+
+### Clone this repo
+
+```bash
+# HTTPS
+git clone https://github.com/FormidableLabs/runpkg.git && cd runpkg
+
+# or use SSH
+git clone git@github.com:FormidableLabs/runpkg.git && cd runpkg
+```
+
+### Install dev dependencies
+
+```bash
+yarn
+# or
+npm i
+```
+
+### Run locally
+
+After installing the dependencies, you can run the `start` script, which will open the app in your default browser:
+
+```bash
+yarn start
+# or
+npm start
+```
+
+> Live reload is enabled by default with [servor](https://github.com/lukejacksonn/servor), so when you make changes to your code the browser will automatically reload the tab to reflect the saved changes.
+
+## Contributor Covenant Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at coc@formidable.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -29,23 +29,7 @@ You will be redirected to runpkg which will display the relevant package and fil
 
 ## Development
 
-If you would like to develop the project, first clone this repo and then install the relevant dependencies:
-
-```bash
-yarn
-# or
-npm i
-```
-
-After this you can run the `start` script, which will open the app in your preferred browser:
-
-```bash
-yarn start
-# or
-npm run start
-```
-
-> Live reload is enabled by default with [servor](https://github.com/lukejacksonn/servor) so when you make changes to your code the browser will reload the tab with any changes reflected immediately.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to run this project locally, contribute, and to see our code of conduct.
 
 ## Local URLs
 


### PR DESCRIPTION
Adds CoC (#138) and moves dev instructions over to a `CONTRIBUTING.md` (#174).

The CoC is a copy of the one used for both Victory and Spectacle, as per @ryan-roemer 's suggestion.

Have not added instructions/conventions for commits, branches and PRs as I think that requires group discussion!