### PR TITLE
Add Netlify badge to welcome screen > #141

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -165,7 +165,7 @@ const styles = {
     }
   `,
   netlifyLogo: css`
-    margin-top: 1rem;
+    margin-top: 2rem;
   `,
   markdown: css`
     color: #fff;

--- a/components/Article.js
+++ b/components/Article.js
@@ -46,11 +46,16 @@ export default () => {
           `
         : html`
             <div className=${styles.welcome}>
-              <a href="https://formidable.com">
+              <a className=${styles.formidaLogo} href="https://formidable.com">
                 ${FormidableLogo}
               </a>
               ${RunpkgIcon}
               <p>Search for and select a package to explore its contents</p>
+              <a className=${styles.netlifyLogo} href="https://www.netlify.com">
+                <img
+                  src="https://www.netlify.com/img/global/badges/netlify-dark.svg"
+                />
+              </a>
             </div>
           `}
       ${fileData.extension === 'md'
@@ -140,15 +145,6 @@ const styles = {
     height: 100%;
     color: rgba(255, 255, 255, 0.62);
     flex: none;
-    a {
-      position: absolute;
-      top: 2vw;
-      left: 2vw;
-      fill: rgba(255, 255, 255, 0.1);
-      svg {
-        width: calc(5rem + 5vw);
-      }
-    }
     svg {
       width: calc(10rem + 5vw);
     }
@@ -158,6 +154,18 @@ const styles = {
       text-align: center;
       line-height: 138%;
     }
+  `,
+  formidaLogo: css`
+    position: absolute;
+    top: 2vw;
+    left: 2vw;
+    fill: rgba(255, 255, 255, 0.1);
+    svg {
+      width: calc(5rem + 5vw);
+    }
+  `,
+  netlifyLogo: css`
+    margin-top: 1rem;
   `,
   markdown: css`
     color: #fff;


### PR DESCRIPTION
Adds Netlify badge to welcome screen, just below the "blurb" below the runpkg logo (#141)

![image](https://user-images.githubusercontent.com/19417581/72242184-5bc6e600-361b-11ea-876d-5245a3a25392.png)

I wasn't sure what the idiomatic way to use this `css` module. Is the way I've implemented it fine/preferred? I was leaning towards just having `.formidaLogo` and `.netlifyLogo` inside the `welcome:  css...` and then doing `className="formidaLogo"` and `className="netlifyLogo"` respectively, instead of `className=${styles.formidaLogo}` etc