### PR TITLE
Prettier enhancement: make script async instead of defer

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,11 +38,11 @@
     <script src="/index.js" type="module-shim"></script>
     <script
       src="https://unpkg.com/prettier@1.13.0/standalone.js"
-      defer
+      async
     ></script>
     <script
       src="https://unpkg.com/prettier@1.13.0/parser-babylon.js"
-      defer
+      async
     ></script>
     <meta property="og:site_name" content="runpkg" />
     <meta property="og:title" content="runpkg | the package explorer" />


### PR DESCRIPTION
Seems like a quick win: avoids blocking `DOMContentLoaded`, resulting in the following performance enhancement (time to interactive (TTI) according to 3x runs of lighthouse desktop performance benchmark for me):

|Thing|TTI (ms)|Delta (ms)|
|---|---|---|
|No prettier|6200|-|
|Defer prettier|6833|+633|
|Async prettier|6567|+367|

So roughly a 266 ms improvement in TTI according to my non-statistically-significant testing