### PR TITLE
Swaps out npms search for algolia search

### DIFF
--- a/components/Main.js
+++ b/components/Main.js
@@ -1,4 +1,4 @@
-import { react, html, css } from '../utils/rplus.js';
+import { react, html, css, npm } from '../utils/rplus.js';
 import { useStateValue } from '../utils/globalState.js';
 import { parseUrl } from '../utils/parseUrl.js';
 
@@ -80,12 +80,15 @@ export default () => {
 
   // Fetch packages by search term
   react.useEffect(() => {
-    fetch(
-      `https://api.npms.io/v2/search/suggestions?size=10&q=${packagesSearchTerm ||
-        'lodash-es'}`
-    )
-      .then(res => res.json())
-      .then(res => res.map(x => x.package))
+    npm
+      .search([
+        {
+          indexName: 'npm-search',
+          attributesToRetrieve: ['name', 'version', 'description'],
+          params: { query: packagesSearchTerm || 'lodash-es' },
+        },
+      ])
+      .then(res => res.results[0].hits)
       .then(res => dispatch({ type: 'setPackages', payload: res }));
   }, [packagesSearchTerm]);
 

--- a/components/Main.js
+++ b/components/Main.js
@@ -85,7 +85,7 @@ export default () => {
         {
           indexName: 'npm-search',
           attributesToRetrieve: ['name', 'version', 'description'],
-          params: { query: packagesSearchTerm || 'lodash-es' },
+          params: { query: packagesSearchTerm || '*' },
         },
       ])
       .then(res => res.results[0].hits)

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
           csz: 'https://unpkg.com/csz@1.1.1/index.js',
           'prism-react-renderer':
             'https://unpkg.com/prism-react-renderer?module',
+          algolia:
+            'https://www.unpkg.com/algoliasearch@4.1.0/dist/algoliasearch-lite.esm.browser.js',
         },
       });
       document.currentScript.after(im);

--- a/utils/rplus.js
+++ b/utils/rplus.js
@@ -3,11 +3,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import htm from 'htm';
 import css from 'csz';
+import search from 'algolia';
 
+const npm = search('OFCNCOG2CU', '86ebd6a34c7fbb7988d5ba5c75d5da34');
 const html = htm.bind(React.createElement);
 const react = {
   ...React,
   render: ReactDOM.render,
 };
 
-export { react, html, css };
+export { react, html, css, npm };


### PR DESCRIPTION
I noticed that the search was broken 👎 and previously was reached out to by Algolia who suggested that their search would be faster an more reliable. My only reservation was that it requires some credentials and an SDK.

But I was given some credentials and their SDK is available as a es module so I gave it a try and indeed it works almost exactly the same as the npms API but is better 🌈.

So unless anyone has an any reason we shouldn't use this service then I'd like to merge asap to get the site back up and functioning properly.