### PR TITLE
fix: use `marked.parse` to satisfy breaking change in marked 4+

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -90,7 +90,7 @@ export default () => {
                 <div className=${styles.markdown}>
                   <div
                     dangerouslySetInnerHTML=${{
-                      __html: marked(fileData.code),
+                      __html: marked.parse(fileData.code),
                     }}
                   ></div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         history.replaceState(null, null, `/?${location.pathname.slice(1)}`);
       }
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@4.0/marked.min.js"></script>
     <script src="./utils/es-module-shim.js" defer></script>
     <script>
       const im = document.createElement('script');


### PR DESCRIPTION
Marked version 4 has a breaking change that requires using `marked.parse(...)` instead of `marked(...)` - [Version 4.0.0 release notes](https://github.com/markedjs/marked/releases/tag/v4.0.0)

This PR just satisfies that requirement.

_-Note-_
Marked is currently included in the project using `<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>`.
Perhaps we should consider locking that to a major or minor version to avoid unexpected breaking changes in future?
(`<script src="https://cdn.jsdelivr.net/npm/marked@4/marked.min.js"></script>`)