### PR TITLE
Move line number to :before

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -108,8 +108,7 @@ export default () => {
                 <span
                   className=${styles.lineNo}
                   onClick=${handleLineNumberClick.bind(null, i + 1)}
-                  >${i + 1}</span
-                >
+                ></span>
                 ${line.map(token => {
                   const dep =
                     fileData.dependencies[removeQuotes(token.content)];
@@ -166,9 +165,13 @@ const styles = {
     margin-right: 2rem;
     opacity: 0.6;
     cursor: pointer;
-    user-select: none;
+    ::before {
+      counter-increment: linenumber;
+      content: counter(linenumber);
+    }
   `,
   code: css`
     line-height: 150%;
+    counter-reset: linenumber 0;
   `,
 };

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -108,6 +108,7 @@ export default () => {
                 <span
                   className=${styles.lineNo}
                   onClick=${handleLineNumberClick.bind(null, i + 1)}
+                  data-linenumber=${i + 1}
                 ></span>
                 ${line.map(token => {
                   const dep =
@@ -166,12 +167,10 @@ const styles = {
     opacity: 0.6;
     cursor: pointer;
     ::before {
-      counter-increment: linenumber;
-      content: counter(linenumber);
+      content: attr(data-linenumber);
     }
   `,
   code: css`
     line-height: 150%;
-    counter-reset: linenumber 0;
   `,
 };


### PR DESCRIPTION
Fixes #194

By using `:before`, Firefox does not run into issues handling `user-select: none;` of the line number spans. Since the number display is now inside the `before`, the line counter was moved to a [CSS counter](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters).