### PR TITLE
Fix dependency trying to import react 18

### DIFF
--- a/components/Editor.js
+++ b/components/Editor.js
@@ -1,5 +1,5 @@
 import { react, html, css } from '../utils/rplus.js';
-import Highlight, { Prism } from 'prism-react-renderer';
+import { Prism, Highlight } from 'prism-react-renderer';
 import { useStateValue } from '../utils/globalState.js';
 import Link from './Link.js';
 

--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
       im.type = 'importmap-shim';
       im.textContent = JSON.stringify({
         imports: {
+          'https://unpkg.com/react@>=16.0.0?module':
+            'https://unpkg.com/es-react@16.11.0/react.js',
           'https://unpkg.com/react@>=0.14.9?module':
             'https://unpkg.com/es-react@16.11.0/react.js',
           'https://unpkg.com/react@16.11.0?module':
@@ -29,7 +31,7 @@
           htm: 'https://unpkg.com/htm@2.2.1/dist/htm.module.js',
           csz: 'https://unpkg.com/csz@1.1.1/index.js',
           'prism-react-renderer':
-            'https://unpkg.com/prism-react-renderer?module',
+            'https://unpkg.com/prism-react-renderer@2.0.6?module',
           algolia:
             'https://www.unpkg.com/algoliasearch@4.1.0/dist/algoliasearch-lite.esm.browser.js',
         },


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/runpkg/issues/213

## Problem

Code returned from `prism-react-renderer?module` on unpkg was instructed to import react to `react@>=16.0.0` which resolved to `react@18.2.0` which was returning `Package react@18.2.0 does not contain an ES module`.

This was breaking the site entirely.

## Solution

- [x] Add rule to import map to rewrite any imports of `react@>=16.0.0` to `es-react@16.11.0/react.js`.
- [x] Adjust the import of `prism-react-rendered` to account for no default export existing anymore.

## Result

The site renders and looks to function correctly again.

