### PR TITLE
Replace `registry.npmjs.cf` with `registry.npmjs.org`

### DIFF
--- a/components/Main.js
+++ b/components/Main.js
@@ -67,7 +67,7 @@ export default () => {
   react.useEffect(() => {
     if (request.name) {
       dispatch({ type: 'setMode', payload: 'package' });
-      fetch(`https://registry.npmjs.cf/${request.name}/`)
+      fetch(`https://registry.npmjs.org/${request.name}/`)
         .then(res => res.json())
         .then(json => {
           dispatch({ type: 'setVersions', payload: json.versions });


### PR DESCRIPTION
`npmjs.cf` has been deprecated: https://github.com/npmjs-cf/meta/issues/8

Since `registry.npmjs.org` also has CORS support now (https://github.com/npm/feedback/discussions/117#discussioncomment-2691120), the PR replaces `registry.npmjs.cf` with `registry.npmjs.org`.