### PR TITLE
fix: limit the initial number of file search results

### DIFF
--- a/components/PackageOverview.js
+++ b/components/PackageOverview.js
@@ -95,8 +95,8 @@ export const PackageOverview = () => {
   ] = useStateValue();
 
   const [
-    showAllSearchResultsForTerm,
-    setShowAllSearchResultsForTerm,
+    searchStringForShowAllResults,
+    setSearchStringForShowAllResults,
   ] = react.useState(null);
 
   const flatFiles = react.useMemo(
@@ -116,12 +116,12 @@ export const PackageOverview = () => {
 
   react.useEffect(() => {
     if (
-      showAllSearchResultsForTerm !== null &&
-      fileSearchTerm !== showAllSearchResultsForTerm
+      searchStringForShowAllResults !== null &&
+      fileSearchTerm !== searchStringForShowAllResults
     ) {
-      setShowAllSearchResultsForTerm(null);
+      setSearchStringForShowAllResults(null);
     }
-  }, [fileSearchTerm, showAllSearchResultsForTerm]);
+  }, [fileSearchTerm, searchStringForShowAllResults]);
 
   if (!versions || !directory || !versions[request.version] || !directory.files)
     return null;
@@ -137,7 +137,8 @@ export const PackageOverview = () => {
   const expandableFilesCount = matchingFiles.length - SEARCH_FILES_RENDER_LIMIT;
 
   const canShowMoreSearchFiles =
-    showAllSearchResultsForTerm !== fileSearchTerm && expandableFilesCount > 0;
+    searchStringForShowAllResults !== fileSearchTerm &&
+    expandableFilesCount > 0;
   const searchFilesToRender = canShowMoreSearchFiles
     ? matchingFiles.slice(0, SEARCH_FILES_RENDER_LIMIT)
     : matchingFiles;
@@ -176,7 +177,7 @@ export const PackageOverview = () => {
                   ? html`
                       <button
                         onClick=${() =>
-                          setShowAllSearchResultsForTerm(fileSearchTerm)}
+                          setSearchStringForShowAllResults(fileSearchTerm)}
                         className=${styles.item}
                       >
                         <div>

--- a/components/PackageOverview.js
+++ b/components/PackageOverview.js
@@ -9,6 +9,8 @@ import formatBytes from '../utils/formatBytes.js';
 
 import { TreeView, TreeItem } from './TreeView.js';
 
+const SEARCH_FILES_RENDER_LIMIT = 100;
+
 const pushState = url => history.pushState(null, null, url);
 
 const flatten = arr =>
@@ -92,6 +94,11 @@ export const PackageOverview = () => {
     dispatch,
   ] = useStateValue();
 
+  const [
+    showAllSearchResultsForTerm,
+    setShowAllSearchResultsForTerm,
+  ] = react.useState(null);
+
   const flatFiles = react.useMemo(
     () => (directory && directory.files ? flatten(directory.files) : []),
     [directory]
@@ -107,6 +114,15 @@ export const PackageOverview = () => {
     [fileSearchTerm]
   );
 
+  react.useEffect(() => {
+    if (
+      showAllSearchResultsForTerm !== null &&
+      fileSearchTerm !== showAllSearchResultsForTerm
+    ) {
+      setShowAllSearchResultsForTerm(null);
+    }
+  }, [fileSearchTerm, showAllSearchResultsForTerm]);
+
   if (!versions || !directory || !versions[request.version] || !directory.files)
     return null;
 
@@ -116,6 +132,15 @@ export const PackageOverview = () => {
     html`
       <option key=${x} value=${x}>${x}</option>
     `;
+
+  const matchingFiles = fileSearchTerm ? flatFiles.filter(search) : [];
+  const expandableFilesCount = matchingFiles.length - SEARCH_FILES_RENDER_LIMIT;
+
+  const canShowMoreSearchFiles =
+    showAllSearchResultsForTerm !== fileSearchTerm && expandableFilesCount > 0;
+  const searchFilesToRender = canShowMoreSearchFiles
+    ? matchingFiles.slice(0, SEARCH_FILES_RENDER_LIMIT)
+    : matchingFiles;
 
   return html`
     <${react.Fragment}>
@@ -136,7 +161,7 @@ export const PackageOverview = () => {
         fileSearchTerm
           ? html`
               <div>
-                ${flatFiles.filter(search).map(
+                ${searchFilesToRender.map(
                   file => html`
                     <${File}
                       key=${file.path}
@@ -147,6 +172,24 @@ export const PackageOverview = () => {
                     />
                   `
                 )}
+                ${canShowMoreSearchFiles
+                  ? html`
+                      <button
+                        onClick=${() =>
+                          setShowAllSearchResultsForTerm(fileSearchTerm)}
+                        className=${styles.item}
+                      >
+                        <div>
+                          <span
+                            >Show${` ${expandableFilesCount} `}more search${' '}
+                            ${expandableFilesCount === 1
+                              ? 'result'
+                              : 'results'}...</span
+                          >
+                        </div>
+                      </button>
+                    `
+                  : null}
               </div>
             `
           : html`
@@ -182,6 +225,8 @@ export const styles = {
     color: rgba(255, 255, 255, 0.8);
 
     text-decoration: none;
+    background: none;
+    cursor: pointer;
     &:hover,
     &:focus {
       color: #fff;


### PR DESCRIPTION
Fixes #191 

This PR resolves a text input performance issue when searching for files. The issue was caused by thousands of files matching the first character of the search, causing a big render lag.
This has been resolved by only rendering a max of 100 file search results, with the option for a user to then choose to render the full list once they have scrolled to the bottom of the initial list.

This video shows how this works

https://github.com/FormidableLabs/runpkg/assets/6524830/5dd60614-18a0-400c-9d27-ef9425cd2fac

